### PR TITLE
Add npm publishing via rosie-skills packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,6 +113,12 @@ jobs:
         with:
           files: rosie-${{ needs.create-release.outputs.version }}.pkg
 
+      - name: Upload rosie binary for npm
+        uses: actions/upload-artifact@v4
+        with:
+          name: rosie-freebsd-x64
+          path: rosie
+
       - name: Commit and push gh-pages
         run: |
           cd pages
@@ -217,3 +223,111 @@ jobs:
           # Rebase to pick up any concurrent push from freebsd job (different subdir, no conflict)
           git pull --rebase origin gh-pages
           git push
+
+  npm-binary-linux-x64:
+    needs: create-release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libarchive-dev pkg-config
+
+      - name: Build rosie
+        run: make release
+
+      - name: Upload rosie binary for npm
+        uses: actions/upload-artifact@v4
+        with:
+          name: rosie-linux-x64
+          path: rosie
+
+  npm-binary-darwin-arm64:
+    needs: create-release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build rosie
+        # No Homebrew: rely on macOS system libcurl/libarchive (Makefile falls
+        # back to `-lcurl -larchive` when pkg-config can't find them). Resulting
+        # binary depends only on macOS system libraries.
+        run: make release
+
+      - name: Verify binary has no Homebrew dependencies
+        run: |
+          if otool -L rosie | grep -qE '/opt/homebrew|/usr/local/Cellar'; then
+            echo "ERROR: binary links against Homebrew libs — not portable"
+            otool -L rosie
+            exit 1
+          fi
+          otool -L rosie
+
+      - name: Upload rosie binary for npm
+        uses: actions/upload-artifact@v4
+        with:
+          name: rosie-darwin-arm64
+          path: rosie
+
+  npm-publish:
+    needs: [create-release, npm-binary-linux-x64, npm-binary-darwin-arm64, freebsd]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download linux-x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rosie-linux-x64
+          path: npm/rosie-skills-linux-x64/bin
+
+      - name: Download darwin-arm64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rosie-darwin-arm64
+          path: npm/rosie-skills-darwin-arm64/bin
+
+      - name: Download freebsd-x64 binary
+        uses: actions/download-artifact@v4
+        with:
+          name: rosie-freebsd-x64
+          path: npm/rosie-skills-freebsd-x64/bin
+
+      - name: Make binaries executable
+        run: chmod +x npm/rosie-skills-*/bin/rosie
+
+      - name: Set versions across all packages
+        env:
+          VERSION: ${{ needs.create-release.outputs.version }}
+        run: |
+          for dir in rosie-skills rosie-skills-linux-x64 rosie-skills-darwin-arm64 rosie-skills-freebsd-x64; do
+            (cd "npm/$dir" && npm version "$VERSION" --no-git-tag-version --allow-same-version)
+          done
+          node -e "
+            const fs = require('fs');
+            const p = 'npm/rosie-skills/package.json';
+            const j = JSON.parse(fs.readFileSync(p, 'utf8'));
+            for (const k of Object.keys(j.optionalDependencies || {})) {
+              j.optionalDependencies[k] = process.env.VERSION;
+            }
+            fs.writeFileSync(p, JSON.stringify(j, null, 2) + '\n');
+          "
+
+      - name: Publish platform packages
+        run: |
+          for dir in rosie-skills-linux-x64 rosie-skills-darwin-arm64 rosie-skills-freebsd-x64; do
+            (cd "npm/$dir" && npm publish)
+          done
+
+      - name: Publish main package
+        run: cd npm/rosie-skills && npm publish

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,0 +1,1 @@
+*/bin/rosie

--- a/npm/rosie-skills-darwin-arm64/package.json
+++ b/npm/rosie-skills-darwin-arm64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rosie-skills-darwin-arm64",
+  "version": "0.0.0",
+  "description": "macOS arm64 binary for rosie-skills",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matthewp/rosie.git"
+  },
+  "homepage": "https://github.com/matthewp/rosie",
+  "license": "BSD-3-Clause",
+  "author": "Matthew Phillips"
+}

--- a/npm/rosie-skills-freebsd-x64/package.json
+++ b/npm/rosie-skills-freebsd-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rosie-skills-freebsd-x64",
+  "version": "0.0.0",
+  "description": "FreeBSD x64 binary for rosie-skills",
+  "os": [
+    "freebsd"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matthewp/rosie.git"
+  },
+  "homepage": "https://github.com/matthewp/rosie",
+  "license": "BSD-3-Clause",
+  "author": "Matthew Phillips"
+}

--- a/npm/rosie-skills-linux-x64/package.json
+++ b/npm/rosie-skills-linux-x64/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rosie-skills-linux-x64",
+  "version": "0.0.0",
+  "description": "Linux x64 binary for rosie-skills",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matthewp/rosie.git"
+  },
+  "homepage": "https://github.com/matthewp/rosie",
+  "license": "BSD-3-Clause",
+  "author": "Matthew Phillips"
+}

--- a/npm/rosie-skills/README.md
+++ b/npm/rosie-skills/README.md
@@ -1,0 +1,44 @@
+# rosie-skills
+
+A fast, cross-platform package manager for AI agent skills.
+
+## Install
+
+```bash
+npm install -g rosie-skills
+```
+
+Or use without installing:
+
+```bash
+npx rosie-skills install owner/repo
+```
+
+## Usage
+
+```bash
+rosie-skills install owner/repo
+rosie-skills list
+rosie-skills --help
+```
+
+See the full documentation at <https://github.com/matthewp/rosie>.
+
+## Supported platforms
+
+Prebuilt binaries are shipped for:
+
+- `linux-x64`
+- `darwin-arm64`
+- `freebsd-x64`
+
+For other platforms, install from source:
+
+- Homebrew: `brew tap matthewp/rosie && brew install rosie`
+- Arch Linux: `yay -S rosie`
+- Debian/Ubuntu: see <https://github.com/matthewp/rosie>
+- Source: clone the repo and run `make release`
+
+## License
+
+BSD-3-Clause

--- a/npm/rosie-skills/bin/rosie-skills.js
+++ b/npm/rosie-skills/bin/rosie-skills.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const pkgName = `rosie-skills-${process.platform}-${process.arch}`;
+
+let binaryPath;
+try {
+  const pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+  binaryPath = path.join(path.dirname(pkgJsonPath), 'bin', 'rosie');
+} catch {
+  console.error(`rosie-skills: no prebuilt binary for ${process.platform}-${process.arch}.`);
+  console.error('Prebuilt platforms: linux-x64, darwin-arm64, freebsd-x64.');
+  console.error('To install on other platforms, build from source: https://github.com/matthewp/rosie');
+  process.exit(1);
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
+
+if (result.error) {
+  console.error(`rosie-skills: failed to execute ${binaryPath}: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/npm/rosie-skills/package.json
+++ b/npm/rosie-skills/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "rosie-skills",
+  "version": "0.0.0",
+  "description": "A fast, cross-platform package manager for AI agent skills",
+  "bin": {
+    "rosie-skills": "bin/rosie-skills.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matthewp/rosie.git"
+  },
+  "homepage": "https://github.com/matthewp/rosie",
+  "license": "BSD-3-Clause",
+  "author": "Matthew Phillips",
+  "engines": {
+    "node": ">=18"
+  },
+  "optionalDependencies": {
+    "rosie-skills-linux-x64": "0.0.0",
+    "rosie-skills-darwin-arm64": "0.0.0",
+    "rosie-skills-freebsd-x64": "0.0.0"
+  }
+}

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -111,11 +111,19 @@
 
       <section class="install">
         <div class="tabs" role="tablist" aria-label="install method">
+          <button class="tab" role="tab" data-tab="npm">[ npm ]</button>
           <button class="tab active" role="tab" data-tab="brew">[ macos ]</button>
           <button class="tab" role="tab" data-tab="aur">[ arch ]</button>
           <button class="tab" role="tab" data-tab="apt">[ debian ]</button>
           <button class="tab" role="tab" data-tab="pkg">[ freebsd ]</button>
           <button class="tab" role="tab" data-tab="src">[ source ]</button>
+        </div>
+
+        <div class="tab-panel" data-panel="npm">
+<pre class="term-block"><span class="prompt">$</span> npx rosie-skills install owner/repo
+<span class="comment"># or install globally</span>
+<span class="prompt">$</span> npm install -g rosie-skills
+<span class="prompt">$</span> rosie-skills install owner/repo<button class="copy-btn" data-copy>[ copy ]</button></pre>
         </div>
 
         <div class="tab-panel active" data-panel="brew">


### PR DESCRIPTION
## Summary

Ships rosie as the [`rosie-skills`](https://www.npmjs.com/package/rosie-skills) npm package so people can do:

```
npx rosie-skills install owner/repo
```

Uses the **optionalDependencies** pattern (esbuild/rolldown-style):

- `rosie-skills` — main package; pure JS, contains a launcher shim that resolves the matching platform package at runtime and execs the native binary
- `rosie-skills-linux-x64` / `rosie-skills-darwin-arm64` / `rosie-skills-freebsd-x64` — platform binary packages; each declares `os` + `cpu` so npm installs only the matching one

Stub `0.0.0` versions of all four package names are already reserved on npm, and **trusted publishers** are configured (GitHub Actions OIDC → no NPM_TOKEN secret required).

## What's in this PR

- `npm/` directory: scaffolding for the four packages (main + three platforms)
- `.github/workflows/release.yaml`: three additions
  - `npm-binary-linux-x64` and `npm-binary-darwin-arm64` build jobs
  - existing `freebsd` job extended to upload the raw `rosie` binary as an artifact
  - `npm-publish` job with `id-token: write`, downloads artifacts, sets versions across all four packages, publishes platform packages then main
- macOS build uses system libcurl/libarchive (no Homebrew), with an `otool -L` guard step that fails the build if any non-system dylib slips in
- `website/public/index.html`: new `[ npm ]` tab in the install section

## Test plan

- [ ] Tag a release (`v0.5.0`) and confirm the workflow runs all `npm-binary-*` build jobs to green
- [ ] Confirm `npm-publish` job completes via OIDC (no token in workflow)
- [ ] On a clean machine: `npx rosie-skills@0.5.0 install anthropics/skills` — verify install works end-to-end
- [ ] Verify the `otool -L` guard step output on the darwin job — confirm the binary links only to `/usr/lib/*` paths
- [ ] Spot check `npm-skills` install section on the live site shows the new tab