### PR TITLE
Add WASM fallback target

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -288,8 +288,28 @@ jobs:
           name: rosie-darwin-arm64
           path: rosie
 
+  wasm-build:
+    needs: create-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build rosie.wasm via emscripten
+        # docker is preinstalled on ubuntu runners; the build script wraps the
+        # same emcc invocation that `make wasm` uses locally with podman.
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src \
+            docker.io/emscripten/emsdk:latest \
+            ./wasm/build.sh
+
+      - name: Upload WASM artifact for npm-publish
+        uses: actions/upload-artifact@v4
+        with:
+          name: rosie-wasm
+          path: npm/rosie-skills/wasm/
+
   npm-publish:
-    needs: [create-release, npm-binary-linux-x64, npm-binary-darwin-arm64, freebsd]
+    needs: [create-release, npm-binary-linux-x64, npm-binary-darwin-arm64, freebsd, wasm-build]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -319,6 +339,12 @@ jobs:
         with:
           name: rosie-freebsd-x64
           path: npm/rosie-skills-freebsd-x64/bin
+
+      - name: Download WASM fallback
+        uses: actions/download-artifact@v4
+        with:
+          name: rosie-wasm
+          path: npm/rosie-skills/wasm
 
       - name: Make binaries executable
         run: chmod +x npm/rosie-skills-*/bin/rosie

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ TARGET = rosie
 # Debug build by default
 CFLAGS += -g -O0
 
-.PHONY: all clean release install uninstall
+PODMAN ?= podman
+EMSDK_IMAGE ?= docker.io/emscripten/emsdk:latest
+
+.PHONY: all clean release install uninstall wasm wasm-clean
 
 all: $(TARGET)
 
@@ -42,6 +45,14 @@ install: $(TARGET)
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/$(TARGET)
+
+# WASM fallback build. Runs inside the emscripten/emsdk container via podman so
+# the host doesn't need emsdk installed. Outputs to npm/rosie-skills/wasm/.
+wasm:
+	$(PODMAN) run --rm --userns=keep-id -v $(CURDIR):/src -w /src $(EMSDK_IMAGE) ./wasm/build.sh
+
+wasm-clean:
+	$(PODMAN) run --rm -v $(CURDIR):/src -w /src $(EMSDK_IMAGE) rm -rf /src/build/wasm /src/npm/rosie-skills/wasm
 
 # Dependencies (auto-generated would be better, but this works)
 $(BUILD_DIR)/main.o: $(SRC_DIR)/main.c $(SRC_DIR)/install.h $(SRC_DIR)/agent.h $(SRC_DIR)/util.h

--- a/npm/.gitignore
+++ b/npm/.gitignore
@@ -1,1 +1,2 @@
 */bin/rosie
+rosie-skills/wasm/

--- a/npm/rosie-skills/bin/rosie-skills.js
+++ b/npm/rosie-skills/bin/rosie-skills.js
@@ -1,25 +1,57 @@
 #!/usr/bin/env node
-const { spawnSync } = require('node:child_process');
+// Launcher for rosie-skills.
+//
+// Resolution order:
+//   1. If ROSIE_FORCE_WASM=1, skip native entirely (for local WASM testing).
+//   2. Try the matching platform package (e.g. rosie-skills-linux-x64) and
+//      exec its native binary.
+//   3. Fall back to the inlined WASM build (wasm/rosie.js) for any platform
+//      we don't ship a native binary for.
+//   4. If neither is available, error out with install instructions.
 const path = require('node:path');
 
-const pkgName = `rosie-skills-${process.platform}-${process.arch}`;
+const forceWasm = process.env.ROSIE_FORCE_WASM === '1';
+const args = process.argv.slice(2);
 
-let binaryPath;
-try {
-  const pkgJsonPath = require.resolve(`${pkgName}/package.json`);
-  binaryPath = path.join(path.dirname(pkgJsonPath), 'bin', 'rosie');
-} catch {
-  console.error(`rosie-skills: no prebuilt binary for ${process.platform}-${process.arch}.`);
-  console.error('Prebuilt platforms: linux-x64, darwin-arm64, freebsd-x64.');
-  console.error('To install on other platforms, build from source: https://github.com/matthewp/rosie');
-  process.exit(1);
+function tryNative() {
+  const pkgName = `rosie-skills-${process.platform}-${process.arch}`;
+  let binaryPath;
+  try {
+    const pkgJsonPath = require.resolve(`${pkgName}/package.json`);
+    binaryPath = path.join(path.dirname(pkgJsonPath), 'bin', 'rosie');
+  } catch {
+    return null;
+  }
+  const { spawnSync } = require('node:child_process');
+  const result = spawnSync(binaryPath, args, { stdio: 'inherit' });
+  if (result.error) {
+    console.error(`rosie-skills: failed to execute ${binaryPath}: ${result.error.message}`);
+    process.exit(1);
+  }
+  process.exit(result.status ?? 1);
 }
 
-const result = spawnSync(binaryPath, process.argv.slice(2), { stdio: 'inherit' });
-
-if (result.error) {
-  console.error(`rosie-skills: failed to execute ${binaryPath}: ${result.error.message}`);
-  process.exit(1);
+function runWasm() {
+  let createRosie;
+  try {
+    createRosie = require(path.join(__dirname, '..', 'wasm', 'rosie.js'));
+  } catch {
+    console.error(`rosie-skills: no native binary for ${process.platform}-${process.arch} and the WASM fallback isn't bundled.`);
+    console.error("This shouldn't happen for a normally-installed package; please file an issue at https://github.com/matthewp/rosie/issues.");
+    process.exit(1);
+  }
+  // The factory's promise resolves on Module instantiation, NOT on main()
+  // completion — so we attach only .catch() and let the event loop drain.
+  // EXIT_RUNTIME=1 throws ExitStatus when C main returns; we surface that
+  // status. Plain resolution (main returned without exiting) → exit 0.
+  createRosie({ arguments: args }).catch(e => {
+    if (e && e.name === 'ExitStatus') process.exit(e.status);
+    console.error(e);
+    process.exit(1);
+  });
 }
 
-process.exit(result.status ?? 1);
+if (!forceWasm) {
+  tryNative();  // exits on success; returns to fall through on no native
+}
+runWasm();

--- a/npm/rosie-skills/package.json
+++ b/npm/rosie-skills/package.json
@@ -6,7 +6,8 @@
     "rosie-skills": "bin/rosie-skills.js"
   },
   "files": [
-    "bin"
+    "bin",
+    "wasm"
   ],
   "repository": {
     "type": "git",

--- a/src/download.c
+++ b/src/download.c
@@ -5,13 +5,16 @@
 #include <string.h>
 #include <unistd.h>
 #include <limits.h>
+#ifndef __EMSCRIPTEN__
 #include <curl/curl.h>
+#endif
 
 #define LOCAL_SOURCE_PREFIX "file://"
 #define LOCAL_SOURCE_PREFIX_LEN 7
 #define NPM_SOURCE_PREFIX "npm:"
 #define NPM_SOURCE_PREFIX_LEN 4
 
+#ifndef __EMSCRIPTEN__
 static bool curl_initialized = false;
 
 int download_init(void) {
@@ -32,6 +35,7 @@ void download_cleanup(void) {
         curl_initialized = false;
     }
 }
+#endif // !__EMSCRIPTEN__
 
 bool source_is_local(const char *source) {
     if (!source) return false;
@@ -263,6 +267,7 @@ char *build_tarball_url(const PackageSpec *spec, RefKind kind) {
     return url;
 }
 
+#ifndef __EMSCRIPTEN__
 static size_t write_callback(void *contents, size_t size, size_t nmemb, void *userp) {
     FILE *fp = (FILE *)userp;
     return fwrite(contents, size, nmemb, fp);
@@ -378,3 +383,4 @@ int download_package_tarball(const PackageSpec *spec, const char *output_path) {
     }
     return 0;
 }
+#endif // !__EMSCRIPTEN__

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -3,9 +3,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef __EMSCRIPTEN__
 #include <curl/curl.h>
+#endif
 
-// --- in-memory curl write target ---
+// --- in-memory fetch target ---
 
 typedef struct {
     char *data;
@@ -13,6 +15,7 @@ typedef struct {
     size_t capacity;
 } MemBuf;
 
+#ifndef __EMSCRIPTEN__
 static size_t mem_write_cb(void *contents, size_t size, size_t nmemb, void *userp) {
     MemBuf *buf = (MemBuf *)userp;
     size_t chunk = size * nmemb;
@@ -73,6 +76,37 @@ static int fetch_refs(const char *owner, const char *repo, MemBuf *out) {
     }
     return 0;
 }
+#else
+// WASM: dispatches through wasm_fetch_to_buffer (implemented in wasm/http-lib.js).
+extern int wasm_fetch_to_buffer(const char *url, const char *accept_header,
+                                char **out_buf, size_t *out_len);
+
+static int fetch_refs(const char *owner, const char *repo, MemBuf *out) {
+    char url[1024];
+    snprintf(url, sizeof(url),
+             "https://github.com/%s/%s/info/refs?service=git-upload-pack",
+             owner, repo);
+
+    out->data = NULL;
+    out->size = 0;
+    out->capacity = 0;
+
+    log_debug("Fetching refs: %s", url);
+    int status = wasm_fetch_to_buffer(url,
+        "application/x-git-upload-pack-advertisement",
+        &out->data, &out->size);
+    if (status < 0) {
+        log_debug("info/refs fetch failed: transport error");
+        return -1;
+    }
+    if (status >= 400) {
+        log_debug("info/refs fetch failed: HTTP %d", status);
+        return -1;
+    }
+    out->capacity = out->size;
+    return 0;
+}
+#endif // __EMSCRIPTEN__
 
 // --- pkt-line parsing ---
 

--- a/wasm/build.sh
+++ b/wasm/build.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# WASM build script for rosie.
+# Designed to be run inside the emscripten/emsdk container (where emcc,
+# emconfigure, emmake are on PATH). Invoke via `make wasm` from the repo root.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD=build/wasm
+OUT=npm/rosie-skills/wasm
+LA_VERSION=3.7.7
+
+mkdir -p "$BUILD" "$OUT"
+
+# -- 1. Cross-compile libarchive (cached) ---------------------------------
+if [ ! -f "$BUILD/libarchive/lib/libarchive.a" ]; then
+  echo ">>> Fetching libarchive $LA_VERSION"
+  rm -rf "$BUILD/libarchive-src"
+  curl -sL "https://github.com/libarchive/libarchive/releases/download/v$LA_VERSION/libarchive-$LA_VERSION.tar.gz" \
+    | tar -xz -C "$BUILD"
+  mv "$BUILD/libarchive-$LA_VERSION" "$BUILD/libarchive-src"
+
+  echo ">>> Configuring libarchive for WASM"
+  cd "$BUILD/libarchive-src"
+  # USE_ZLIB=1 surfaces emscripten's bundled zlib to autoconf so libarchive
+  # detects it and links its built-in gzip codec — otherwise libarchive falls
+  # back to spawning /bin/gzip at runtime, which doesn't exist in WASM.
+  CFLAGS="-sUSE_ZLIB=1" LDFLAGS="-sUSE_ZLIB=1" \
+  emconfigure ./configure \
+    --prefix="$REPO_ROOT/$BUILD/libarchive" \
+    --enable-static --disable-shared \
+    --with-zlib \
+    --without-iconv --without-xml2 --without-expat \
+    --without-bz2lib --without-lzma --without-zstd --without-lz4 \
+    --without-openssl --without-mbedtls --without-cng \
+    --without-nettle \
+    --disable-bsdtar --disable-bsdcpio --disable-bsdcat \
+    --disable-acl --disable-xattr
+  echo ">>> Building libarchive"
+  EMCC_CFLAGS="-sUSE_ZLIB=1" emmake make -j"$(nproc)"
+  emmake make install
+  cd "$REPO_ROOT"
+fi
+
+# -- 2. Compile + link rosie.wasm -----------------------------------------
+# download.c and resolve.c contain `#ifndef __EMSCRIPTEN__` guards around
+# their curl-using code; emcc defines __EMSCRIPTEN__ automatically, so those
+# blocks drop out. wasm/http-stub.c supplies the missing HTTP entry points.
+SRCS=(
+  src/agent.c src/agentsmd.c src/archive.c src/download.c
+  src/install.c src/lockfile.c src/main.c src/npm.c src/resolve.c
+  src/skill.c src/util.c
+  wasm/http-stub.c
+)
+
+echo ">>> Compiling rosie.wasm"
+emcc "${SRCS[@]}" \
+  -O2 \
+  -Wall -Wextra \
+  -std=c99 \
+  -D_POSIX_C_SOURCE=200809L -D_DEFAULT_SOURCE \
+  -I"$BUILD/libarchive/include" \
+  "$BUILD/libarchive/lib/libarchive.a" \
+  -sUSE_ZLIB=1 \
+  -sASYNCIFY=1 \
+  -sALLOW_MEMORY_GROWTH=1 \
+  -sINITIAL_MEMORY=33554432 \
+  -sMODULARIZE=1 \
+  -sEXPORT_NAME=createRosie \
+  -sENVIRONMENT=node \
+  -sNODERAWFS=1 \
+  -sEXIT_RUNTIME=1 \
+  --js-library wasm/http-lib.js \
+  -o "$OUT/rosie.js"
+
+echo ">>> Build complete:"
+ls -la "$OUT/"

--- a/wasm/http-lib.js
+++ b/wasm/http-lib.js
@@ -1,0 +1,69 @@
+// JS-side HTTP implementations the WASM build calls into.
+//
+// emcc bakes these into the generated rosie.js via --js-library. Each
+// `<name>__async: true` declaration tells emcc the function awaits a promise;
+// Asyncify pauses the WASM stack, lets the promise resolve, then resumes.
+//
+// Return convention: HTTP status code on transport success, -1 on transport
+// error (DNS, network, etc.). 404 / 5xx etc. are returned as-is so callers
+// can distinguish "not found, try as tag" from "the network is down."
+
+addToLibrary({
+  // int wasm_fetch_to_file(const char *url, const char *output_path)
+  // Streams the response body straight to output_path (no buffering of the
+  // full tarball in WASM memory). Used for tarball downloads.
+  wasm_fetch_to_file__async: true,
+  wasm_fetch_to_file: function(url_ptr, output_path_ptr) {
+    const url = UTF8ToString(url_ptr);
+    const output_path = UTF8ToString(output_path_ptr);
+    return Asyncify.handleAsync(async () => {
+      try {
+        const res = await fetch(url, {
+          headers: { 'User-Agent': 'rosie/1.0' },
+          redirect: 'follow',
+        });
+        const buf = Buffer.from(await res.arrayBuffer());
+        // Only write the file on 2xx — matches curl's behavior of removing a
+        // partial file on HTTP error so the caller doesn't see a junk file.
+        if (res.ok) {
+          require('fs').writeFileSync(output_path, buf);
+        }
+        return res.status;
+      } catch (e) {
+        if (typeof console !== 'undefined') console.error('fetch error:', e.message);
+        return -1;
+      }
+    });
+  },
+
+  // int wasm_fetch_to_buffer(const char *url, const char *accept_header,
+  //                         char **out_buf, size_t *out_len)
+  // Buffers the body in WASM-allocated memory; writes the pointer + length
+  // through the out parameters so the C caller can spm_free() it. Used for
+  // the GitHub info/refs response (small).
+  wasm_fetch_to_buffer__async: true,
+  wasm_fetch_to_buffer__deps: ['malloc'],
+  wasm_fetch_to_buffer: function(url_ptr, accept_ptr, out_buf_pp, out_len_p) {
+    const url = UTF8ToString(url_ptr);
+    const accept = accept_ptr ? UTF8ToString(accept_ptr) : null;
+    return Asyncify.handleAsync(async () => {
+      try {
+        const headers = { 'User-Agent': 'git/rosie-1.0' };
+        if (accept) headers['Accept'] = accept;
+        const res = await fetch(url, { headers, redirect: 'follow' });
+        if (!res.ok) return res.status;
+        const bytes = new Uint8Array(await res.arrayBuffer());
+        const buf_ptr = _malloc(bytes.length + 1);
+        HEAPU8.set(bytes, buf_ptr);
+        HEAPU8[buf_ptr + bytes.length] = 0;  // null-terminate for safety
+        // wasm32: pointers + size_t are 32-bit, so HEAPU32 is correct.
+        HEAPU32[out_buf_pp >> 2] = buf_ptr;
+        HEAPU32[out_len_p >> 2] = bytes.length;
+        return res.status;
+      } catch (e) {
+        if (typeof console !== 'undefined') console.error('fetch error:', e.message);
+        return -1;
+      }
+    });
+  },
+});

--- a/wasm/http-stub.c
+++ b/wasm/http-stub.c
@@ -1,0 +1,64 @@
+// WASM HTTP implementations.
+//
+// Replaces the curl-using code that download.c and resolve.c #ifndef out for
+// __EMSCRIPTEN__ builds. The actual transport lives in wasm/http-lib.js,
+// linked via --js-library at build time. Asyncify lets the JS side await on
+// fetch() while the C call looks synchronous from this side.
+//
+// Convention: wasm_fetch_* return the HTTP status code on transport success
+// (which the C caller inspects to differentiate 200/404/etc.), or -1 on
+// transport failure (network unreachable, bad URL, etc.).
+
+#include "../src/download.h"
+#include "../src/util.h"
+#include <stddef.h>
+
+// Implemented in wasm/http-lib.js.
+extern int wasm_fetch_to_file(const char *url, const char *output_path);
+
+int download_init(void) {
+    return 0;
+}
+
+void download_cleanup(void) {
+}
+
+int download_file(const char *url, const char *output_path) {
+    int status = wasm_fetch_to_file(url, output_path);
+    if (status < 0) {
+        log_error("Download failed");
+        return -1;
+    }
+    if (status >= 400) {
+        log_error("HTTP error: %d", status);
+        return -1;
+    }
+    return 0;
+}
+
+int download_package_tarball(const PackageSpec *spec, const char *output_path) {
+    if (!spec) return -1;
+
+    char *url = build_tarball_url(spec, REF_KIND_BRANCH);
+    int status = wasm_fetch_to_file(url, output_path);
+    spm_free(url);
+
+    if (status < 0) return -1;
+    if (status < 400) return 0;
+    if (status != 404) {
+        log_error("HTTP error: %d", status);
+        return -1;
+    }
+
+    log_debug("Ref '%s' not found as branch, trying as tag", spec->ref);
+    url = build_tarball_url(spec, REF_KIND_TAG);
+    status = wasm_fetch_to_file(url, output_path);
+    spm_free(url);
+
+    if (status < 0) return -1;
+    if (status >= 400) {
+        log_error("Ref '%s' not found as branch or tag (HTTP %d)", spec->ref, status);
+        return -1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

Builds `rosie.wasm` via emscripten so the `rosie-skills` npm package works on platforms we don't ship native binaries for (Windows, linux-arm64, darwin-x64, etc.). Lays foundation for an in-process JS API later.

**Hybrid approach** — WASM does archive extraction and all the rosie logic; Node's built-in `fetch` handles HTTP, bridged into C through Asyncify so the C call sites look synchronous.

## What's in this PR

- `wasm/build.sh` — cross-compiles libarchive (with zlib for tar.gz, everything else disabled) and links `rosie.wasm`. Cached: first run ~3 min, subsequent ~10s.
- `wasm/http-stub.c` — provides `download_init` / `download_cleanup` / `download_file` / `download_package_tarball` for the WASM build. Routes through extern JS functions.
- `wasm/http-lib.js` — Node-side `fetch` implementations using `Asyncify.handleAsync` so async fetches look sync to C.
- `src/download.c` + `src/resolve.c` — curl code wrapped in `#ifndef __EMSCRIPTEN__`; resolve.c gets a parallel WASM-path `fetch_refs` using the same JS bridge.
- `npm/rosie-skills/bin/rosie-skills.js` — shim now tries native first, falls back to inlined WASM. `ROSIE_FORCE_WASM=1` overrides for local testing.
- `Makefile` — `make wasm` / `make wasm-clean` invoke `emscripten/emsdk` via `podman` with `--userns=keep-id` so outputs land owned by the host user.
- `.github/workflows/release.yaml` — new `wasm-build` job runs the same script via `docker`; `npm-publish` stages the artifact into `npm/rosie-skills/wasm/` before publish.

## Footprint

`~365 KB rosie.wasm` + `~94 KB rosie.js` inlined into the `rosie-skills` main package. Well under the 1-3 MB ceiling I estimated.

## Test plan

- [x] `make release` still produces a working native binary (no regression from the `#ifndef __EMSCRIPTEN__` wrapping)
- [x] `make wasm` builds locally via podman, output in `npm/rosie-skills/wasm/`
- [x] `ROSIE_FORCE_WASM=1 rosie-skills --version` → `0.5.3` (uses WASM path)
- [x] `ROSIE_FORCE_WASM=1 rosie-skills install anthropics/skills` in tmpdir → 51 skills installed via real host symlinks, lockfile written
- [ ] CI: confirm `wasm-build` job runs to green
- [ ] CI: confirm `npm-publish` job stages the WASM artifact and publishes a `rosie-skills` package that includes `wasm/rosie.{js,wasm}`
- [ ] Post-release: smoke-test `npx rosie-skills install owner/repo` on a platform we *don't* ship a native binary for (Windows or linux-arm64) to confirm the WASM fallback kicks in