### PR TITLE
Don't treat consumer-side install dirs as package skill sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ target/
 !tests/regression/cases/*/expected/.claude/
 !tests/regression/cases/*/expected/.opencode/
 !tests/regression/cases/*/expected/.cursor/
+# Fixture sources may contain dot-dirs that simulate consumer-side install
+# state (e.g. a project that committed its installed third-party skills).
+!tests/regression/fixtures/sources/**/.agents/
+!tests/regression/fixtures/sources/**/.claude/
+!tests/regression/fixtures/sources/**/.opencode/
+!tests/regression/fixtures/sources/**/.cursor/

--- a/src/skill.rs
+++ b/src/skill.rs
@@ -22,16 +22,14 @@ pub struct Skill {
     pub skill_file: PathBuf,
 }
 
-/// Default search paths checked in order, relative to the project root.
-/// Matches `SKILL_SEARCH_PATHS` in skill.c.
-const SKILL_SEARCH_PATHS: &[&str] = &[
-    "skills",
-    ".agents/skills",
-    ".claude/skills",
-    ".cursor/skills",
-    ".cline/skills",
-    ".codex/skills",
-];
+/// Search paths checked in order when looking inside a *package* for the
+/// skills it ships. Intentionally narrow: `skills/` is the convention, and
+/// the recursive fallback below catches anything off-convention. We do not
+/// scan agent-specific directories like `.agents/skills`, `.claude/skills`,
+/// `.cursor/skills`, etc. — those are consumer-side install destinations,
+/// so a project that committed its installed third-party skills would have
+/// them mistakenly republished.
+const SKILL_SEARCH_PATHS: &[&str] = &["skills"];
 
 /// Parse SKILL.md frontmatter. Returns None on read error or when no name
 /// can be derived from frontmatter or the parent directory name.

--- a/tests/regression/cases/install-skips-installed-skills/assertions.sh
+++ b/tests/regression/cases/install-skips-installed-skills/assertions.sh
@@ -1,0 +1,5 @@
+assert_exit_code 0 "$(cat exit_code)"
+assert_contains stdout "Found 1 skill(s)"
+assert_contains stdout "genuine"
+assert_not_contains stdout "installed-thirdparty"
+assert_symlink_target ".claude/skills/genuine" "../../.agents/skills/genuine"

--- a/tests/regression/cases/install-skips-installed-skills/expected/.agents/rosie.lock
+++ b/tests/regression/cases/install-skips-installed-skills/expected/.agents/rosie.lock
@@ -1,0 +1,2 @@
+# rosie-lock v1
+genuine fake-org/contaminated main - TIMESTAMP auto skill

--- a/tests/regression/cases/install-skips-installed-skills/expected/.agents/skills/genuine/SKILL.md
+++ b/tests/regression/cases/install-skips-installed-skills/expected/.agents/skills/genuine/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: genuine
+description: A skill the package actually authors and ships
+---
+
+# genuine
+
+Body.

--- a/tests/regression/cases/install-skips-installed-skills/expected/.claude/skills/genuine
+++ b/tests/regression/cases/install-skips-installed-skills/expected/.claude/skills/genuine
@@ -1,0 +1,1 @@
+../../.agents/skills/genuine

--- a/tests/regression/cases/install-skips-installed-skills/run.sh
+++ b/tests/regression/cases/install-skips-installed-skills/run.sh
@@ -1,0 +1,11 @@
+# install-skips-installed-skills: a repo whose tree contains both a real
+# `skills/genuine/SKILL.md` and a consumer-side `.claude/skills/installed-
+# thirdparty/SKILL.md` (i.e. a third-party skill some consumer project had
+# rosie install and then committed). When this repo is itself installed,
+# rosie should only see the genuine author-shipped skill, not the
+# installed-thirdparty one.
+
+mkdir -p "$HOME/.claude"
+
+"$ROSIE" install -y fake-org/contaminated > stdout 2> stderr
+echo $? > exit_code

--- a/tests/regression/fixtures/build.sh
+++ b/tests/regression/fixtures/build.sh
@@ -70,7 +70,9 @@ find "$SOURCES" -mindepth 3 -maxdepth 3 -type d | while read -r ref_dir; do
 
     # Sanity check: confirm we actually emitted a pax_global_header so
     # future build-script changes can't silently lose this property.
-    first_record=$(zcat "$out_tar" | head -c 100 | tr -d '\0' | head -n 1)
+    # gunzip -c works on both GNU and BSD systems; macOS `zcat` only
+    # handles the old .Z compress format, not gzip.
+    first_record=$(gunzip -c "$out_tar" | head -c 100 | tr -d '\0' | head -n 1)
     if [ "$first_record" != "pax_global_header" ]; then
         echo "error: $out_tar first record is '$first_record', expected 'pax_global_header'" >&2
         echo "       (the GNU tar on this system may not support --format=pax globexthdr)" >&2

--- a/tests/regression/fixtures/sources/fake-org/contaminated/main/.claude/skills/installed-thirdparty/SKILL.md
+++ b/tests/regression/fixtures/sources/fake-org/contaminated/main/.claude/skills/installed-thirdparty/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: installed-thirdparty
+description: Represents a consumer-installed third-party skill that the project happened to commit. rosie must not treat these as the package's own skills when this repo is being installed.
+---
+
+# installed-thirdparty
+
+Should never be discovered by `rosie install fake-org/contaminated`.

--- a/tests/regression/fixtures/sources/fake-org/contaminated/main/skills/genuine/SKILL.md
+++ b/tests/regression/fixtures/sources/fake-org/contaminated/main/skills/genuine/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: genuine
+description: A skill the package actually authors and ships
+---
+
+# genuine
+
+Body.

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -684,7 +684,7 @@ Instructions for the AI agent go here…
     <li>
       <span class="bullet">▸</span>
       <strong class="key">discovery</strong>
-      <span class="val">rosie searches <code>skills/</code>, <code>.agents/skills/</code>, <code>.claude/skills/</code>, and other known paths for <code>SKILL.md</code> files</span>
+      <span class="val">rosie walks the repo for <code>SKILL.md</code> files — see <a href="#discovery">discovery</a> for the exact algorithm</span>
     </li>
     <li>
       <span class="bullet">▸</span>
@@ -697,6 +697,36 @@ Instructions for the AI agent go here…
       <span class="val"><code>scripts/</code>, <code>references/</code>, anything else in the directory travels with the skill — the agent can use them</span>
     </li>
   </ul>
+</section>
+
+<div class="section-rule" id="discovery">
+  <span class="dashes">──</span>
+  <a href="#discovery" class="label">discovery</a>
+  <span class="dashes-grow"></span>
+</div>
+
+<section class="discovery">
+  <p class="lockfile-intro">when rosie installs a repo, it walks the extracted tree looking for <code>SKILL.md</code> files. three layers, checked in order:</p>
+
+  <ul class="bullet-list">
+    <li>
+      <span class="bullet">1</span>
+      <strong class="key">root <code>SKILL.md</code></strong>
+      <span class="val">single-skill repos where the repo root <em>is</em> the skill</span>
+    </li>
+    <li>
+      <span class="bullet">2</span>
+      <strong class="key"><code>skills/</code> subdir</strong>
+      <span class="val">conventional layout: <code>skills/&lt;name&gt;/SKILL.md</code></span>
+    </li>
+    <li>
+      <span class="bullet">3</span>
+      <strong class="key">recursive walk (fallback)</strong>
+      <span class="val">only runs when layers 1 and 2 found nothing · descends into any non-hidden subdirectory · stops at the first <code>SKILL.md</code> on each branch · max depth 5</span>
+    </li>
+  </ul>
+
+  <p class="lockfile-intro">dot-directories are intentionally skipped — that includes consumer-side install destinations like <code>.agents/skills/</code>, <code>.claude/skills/</code>, <code>.cursor/skills/</code>, etc. Those are where rosie installs <em>into</em>, not where a package authors its own skills. A project that commits its installed third-party skills will not have them re-published when its own repo is installed as a package.</p>
 </section>
 
 <div class="section-rule" id="how-it-works">


### PR DESCRIPTION
## Summary
- Trim `SKILL_SEARCH_PATHS` so `rosie install <repo>` no longer scans `.agents/skills`, `.claude/skills`, `.cursor/skills`, `.cline/skills`, or `.codex/skills` as if they held the package's own skills. Those dirs are consumer-side install destinations; a project that committed its installed third-party skills would otherwise re-publish them.
- Add regression case `install-skips-installed-skills` with a fixture that ships `skills/genuine/` alongside a contaminating `.claude/skills/installed-thirdparty/`. Confirms only `genuine` is discovered.
- Document the discovery algorithm (root SKILL.md → `skills/` → recursive fallback, with dot-dirs skipped) in its own new `discovery` section on the website docs.
- Drive-by: fixture builder uses `gunzip -c` instead of `zcat` so macOS CI doesn't choke on the pax sanity check (BSD `zcat` is `.Z`-only).

## Test plan
- [x] `cargo build --release`
- [x] `tests/regression/run.sh --binary ./target/release/rosie` — all 37 cases pass
- [x] Confirmed the new case fails on the un-trimmed code (`Found 2 skill(s)`, installed-thirdparty in the lockfile) and passes after the trim
- [ ] CI green on linux + macOS