### PR TITLE
Silence node:wasi ExperimentalWarning in the wasm fallback

### DIFF
--- a/npm/rosie-skills/src/bin.ts
+++ b/npm/rosie-skills/src/bin.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
+import { silenceWasiExperimentalWarning } from "./silence-wasi-warning.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -47,6 +48,7 @@ interface WasmModule {
 }
 
 async function runWasm(): Promise<void> {
+  silenceWasiExperimentalWarning();
   const wasmEntry = path.join(__dirname, "..", "wasm", "rosie.js");
   let createRosie: () => Promise<WasmModule>;
   try {

--- a/npm/rosie-skills/src/silence-wasi-warning.ts
+++ b/npm/rosie-skills/src/silence-wasi-warning.ts
@@ -1,0 +1,28 @@
+// Suppress Node's ExperimentalWarning about `node:wasi` being unstable.
+// The wasm fallback uses node:wasi via wasm/shim.js, and Node prints the
+// warning to stderr the first time the module is imported. The warning is
+// noise to a CLI/library user — they didn't choose WASI, we did — so we
+// intercept it at the emitter.
+//
+// Patches process.emit('warning'); leaves every other warning untouched.
+// Safe to call multiple times (the second patch wraps the first, which
+// still defers to Node's original emit at the bottom of the chain).
+export function silenceWasiExperimentalWarning(): void {
+  const originalEmit = process.emit.bind(process);
+  (process.emit as unknown) = function (
+    name: string | symbol,
+    ...args: unknown[]
+  ): boolean {
+    if (name === "warning") {
+      const w = args[0] as { name?: string; message?: string } | undefined;
+      if (
+        w &&
+        w.name === "ExperimentalWarning" &&
+        (w.message ?? "").startsWith("WASI is an experimental feature")
+      ) {
+        return false;
+      }
+    }
+    return (originalEmit as (n: string | symbol, ...a: unknown[]) => boolean)(name, ...args);
+  };
+}

--- a/npm/rosie-skills/src/wasm-loader.ts
+++ b/npm/rosie-skills/src/wasm-loader.ts
@@ -10,6 +10,7 @@
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { silenceWasiExperimentalWarning } from "./silence-wasi-warning.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -63,6 +64,7 @@ let modulePromise: Promise<RosieModule> | null = null;
 async function getOrLoadModule(): Promise<RosieModule> {
   if (modulePromise) return modulePromise;
 
+  silenceWasiExperimentalWarning();
   const wasmEntry = path.join(__dirname, "..", "wasm", "rosie.js");
   const mod = (await import(wasmEntry)) as { default: RosieFactory };
   const createRosie = mod.default;


### PR DESCRIPTION
## Summary
Node emits a one-shot `ExperimentalWarning: WASI is an experimental feature…` to stderr the first time `node:wasi` is imported. Our wasm fallback (`wasm/shim.js`, copied to `npm/rosie-skills/wasm/rosie.js` by `wasm/build.sh`) imports that module to set up preopens for the asyncify-instrumented binary, so any user who lands on the wasm path — every JS API caller and any CLI invocation without a matching platform binary — sees the warning.

Add a small helper that patches `process.emit('warning')` with a narrow filter: drops only the exact WASI ExperimentalWarning, lets every other warning pass through Node's default handler. Called from both wasm entry points (`bin.ts` and `wasm-loader.ts`) right before the wasm dynamic import.

## Test plan
- [x] `npm run build` clean
- [x] Confirmed the silencer drops the WASI warning in isolation (`node -e 'await import("node:wasi")'`)
- [x] Confirmed unrelated `ExperimentalWarning`s and other warning kinds still pass through (regex anchored to `^WASI is an experimental feature`)
- [ ] CI green