### PR TITLE
Fix WASM fallback failing to load on Windows (#11)

### DIFF
--- a/npm/rosie-skills/src/bin.ts
+++ b/npm/rosie-skills/src/bin.ts
@@ -9,13 +9,16 @@
 //      we don't ship a native binary for.
 
 import * as path from "node:path";
+import * as fs from "node:fs";
 import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { silenceWasiExperimentalWarning } from "./silence-wasi-warning.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
+// File URL for the WASM shim. URLs (not filesystem paths) keep dynamic
+// import() portable — on Windows, import() of an absolute path fails with
+// ERR_UNSUPPORTED_ESM_URL_SCHEME.
+const WASM_ENTRY_URL = new URL("../wasm/rosie.js", import.meta.url);
 
 const forceWasm = process.env.ROSIE_FORCE_WASM === "1";
 const args = process.argv.slice(2);
@@ -49,18 +52,24 @@ interface WasmModule {
 
 async function runWasm(): Promise<void> {
   silenceWasiExperimentalWarning();
-  const wasmEntry = path.join(__dirname, "..", "wasm", "rosie.js");
-  let createRosie: () => Promise<WasmModule>;
-  try {
-    const mod = (await import(wasmEntry)) as { default: typeof createRosie };
-    createRosie = mod.default;
-  } catch {
+  // Pre-check existence so a genuinely missing bundle produces a helpful
+  // "not bundled" message rather than a confusing module-resolution error.
+  if (!fs.existsSync(WASM_ENTRY_URL)) {
     console.error(
       `rosie-skills: no native binary for ${process.platform}-${process.arch} and the WASM fallback isn't bundled.`
     );
     console.error(
       "This shouldn't happen for a normally-installed package; please file an issue at https://github.com/matthewp/rosie/issues."
     );
+    process.exit(1);
+  }
+  let createRosie: () => Promise<WasmModule>;
+  try {
+    const mod = (await import(WASM_ENTRY_URL.href)) as { default: typeof createRosie };
+    createRosie = mod.default;
+  } catch (e) {
+    console.error(`rosie-skills: failed to load WASM fallback at ${WASM_ENTRY_URL.href}: ${(e as Error).message}`);
+    console.error("Please file an issue at https://github.com/matthewp/rosie/issues.");
     process.exit(1);
   }
   const m = await createRosie();

--- a/npm/rosie-skills/src/wasm-loader.ts
+++ b/npm/rosie-skills/src/wasm-loader.ts
@@ -8,11 +8,12 @@
 // (`__rosieLog__`). We can't use Module.print here because NODERAWFS routes
 // printf to host fd 1/2 directly, bypassing the Module hook.
 
-import * as path from "node:path";
-import { fileURLToPath } from "node:url";
 import { silenceWasiExperimentalWarning } from "./silence-wasi-warning.js";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// File URL for the WASM shim. Using a URL (not a filesystem path) keeps
+// dynamic import() portable — on Windows, import() of an absolute path
+// fails with ERR_UNSUPPORTED_ESM_URL_SCHEME.
+const WASM_ENTRY_URL = new URL("../wasm/rosie.js", import.meta.url);
 
 export type LogLevel = "error" | "warn" | "info" | "debug";
 
@@ -65,8 +66,7 @@ async function getOrLoadModule(): Promise<RosieModule> {
   if (modulePromise) return modulePromise;
 
   silenceWasiExperimentalWarning();
-  const wasmEntry = path.join(__dirname, "..", "wasm", "rosie.js");
-  const mod = (await import(wasmEntry)) as { default: RosieFactory };
+  const mod = (await import(WASM_ENTRY_URL.href)) as { default: RosieFactory };
   const createRosie = mod.default;
 
   modulePromise = (async () => {

--- a/tests/wasm-parity/run.mjs
+++ b/tests/wasm-parity/run.mjs
@@ -11,15 +11,13 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const PORT = parseInt(process.env.PORT ?? '8765', 10);
 
-// Bind to the JS API in the built dist/.
-const apiPath = path.join(REPO_ROOT, 'npm', 'rosie-skills', 'dist', 'index.js');
-const rosie = await import(apiPath);
+// Bind to the JS API in the built dist/. Use a file:// URL so dynamic
+// import() works the same on Windows (where absolute paths are rejected).
+const apiUrl = new URL('../../npm/rosie-skills/dist/index.js', import.meta.url);
+const rosie = await import(apiUrl.href);
 
 let passed = 0;
 let failed = 0;

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "rosie"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "flate2",
  "junction",

--- a/wasm/shim.js
+++ b/wasm/shim.js
@@ -17,24 +17,31 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import { WASI } from 'node:wasi';
-import { fileURLToPath } from 'node:url';
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const WASM_PATH = path.join(__dirname, 'rosie.wasm');
+// File URL for rosie.wasm sitting alongside this shim. Node's fs accepts
+// URLs directly — avoiding fileURLToPath keeps Windows paths from getting
+// mangled.
+const WASM_URL = new URL('./rosie.wasm', import.meta.url);
 
 // ---------------------------------------------------------------------------
 // createRosie({ noInitialRun?, print?, printErr?, arguments?, onAbort? })
 // ---------------------------------------------------------------------------
 
 async function createRosie(opts = {}) {
-    const wasmBytes = fs.readFileSync(WASM_PATH);
+    const wasmBytes = fs.readFileSync(WASM_URL);
     const module = await WebAssembly.compile(wasmBytes);
 
+    // Rosie's wasm never touches WASI fs syscalls (all file ops route
+    // through the rosie_fs_* env imports below), so the sandbox preopens
+    // here are nominal. Map both to the host tmpdir, which exists on every
+    // platform — on Windows '/tmp' isn't a real path and would make WASI
+    // initialization fail.
+    const tmp = os.tmpdir();
     const wasi = new WASI({
         version: 'preview1',
         args: opts.arguments ?? ['rosie'],
         env: process.env,
-        preopens: { '/': '/', '/tmp': '/tmp' },
+        preopens: { '/': tmp, '/tmp': tmp },
     });
 
     // Per-instance state owned by the closure below. Captured before


### PR DESCRIPTION
## Summary
- Fixes #11. On Windows `npx rosie-skills install owner/repo` printed `no native binary for win32-x64 and the WASM fallback isn't bundled`, even though it was bundled. The real failure was a swallowed `ERR_UNSUPPORTED_ESM_URL_SCHEME` from `import()` of an absolute filesystem path.
- Switch the WASM fallback and the wasm-parity test to URL-based module resolution end-to-end: `new URL("../wasm/rosie.js", import.meta.url)` then `import(url.href)`. Node's `fs.readFileSync` / `fs.existsSync` accept URLs too, so `fileURLToPath` / `path.join` go away entirely.
- Remap the WASI sandbox preopens from hardcoded `/tmp` to `os.tmpdir()` so WASI initialization succeeds on Windows. Rosie's wasm never touches WASI fs syscalls (everything routes through the `rosie_fs_*` env imports), so the preopens are nominal — they just need to point at a path that exists on the host.
- Improve `bin.ts` error handling: pre-check the bundle exists so the "not bundled" message stays accurate; if `import()` fails for any other reason, surface the real error instead of eating it.

## Test plan
- [x] `./tests/wasm-parity/run.sh` — all 17 cases pass on Linux against the rebuilt `rosie.wasm`.
- [x] `ROSIE_FORCE_WASM=1 node dist/bin.js --version` — prints `0.7.0`.
- [ ] Verify on a Windows host that `npx rosie-skills install owner/repo` no longer fails at module load.