### PR TITLE
Fix OpenCode auto-detection to check .config/opencode

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -27,7 +27,7 @@ pub const AGENT_DEFS: &[AgentDef] = &[
     // --- Original 12 (paths fixed for amplify->augment, aider->.aider-desk, copilot) ---
     AgentDef { name: "claude",     display: "Claude Code",     aliases: &[],           project_path: ".claude/skills",     global_path: ".claude/skills",          detect_dir: ".claude",          binary: Some("claude") },
     AgentDef { name: "cursor",     display: "Cursor",          aliases: &[],           project_path: ".cursor/skills",     global_path: ".cursor/skills",          detect_dir: ".cursor",          binary: Some("cursor") },
-    AgentDef { name: "opencode",   display: "OpenCode",        aliases: &[],           project_path: ".opencode/skills",   global_path: ".config/opencode/skills", detect_dir: ".opencode",        binary: Some("opencode") },
+    AgentDef { name: "opencode",   display: "OpenCode",        aliases: &[],           project_path: ".opencode/skills",   global_path: ".config/opencode/skills", detect_dir: ".config/opencode", binary: Some("opencode") },
     AgentDef { name: "cline",      display: "Cline",           aliases: &[],           project_path: ".cline/skills",      global_path: ".cline/skills",           detect_dir: ".cline",           binary: None },
     AgentDef { name: "codex",      display: "Codex",           aliases: &[],           project_path: ".codex/skills",      global_path: ".codex/skills",           detect_dir: ".codex",           binary: Some("codex") },
     AgentDef { name: "windsurf",   display: "Windsurf",        aliases: &[],           project_path: ".windsurf/skills",   global_path: ".codeium/windsurf/skills", detect_dir: ".windsurf",       binary: None },


### PR DESCRIPTION
## Summary

- OpenCode stores its config at `~/.config/opencode` (XDG), not `~/.opencode`. The `detect_dir` on the `opencode` AgentDef was still pointing at the legacy path even though `global_path` had already been migrated.
- Effect: users with OpenCode installed at the XDG location weren't being detected, so OpenCode didn't appear in install results or fan-out targets.
- Other XDG-based agents (Goose, Crush, Amp) were already correct; this brings OpenCode in line.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib agent` passes
- [ ] Manual: create `~/.config/opencode/`, run `rosie agents`, verify OpenCode shows as detected
- [ ] Manual: run an install with the JS API on a host with `~/.config/opencode/`, verify OpenCode appears in `installedAgents`