### PR TITLE
Support local-path installs with --global

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,7 +30,9 @@ fn print_usage(prog: &str) {
     println!();
     println!("Options:");
     println!("  -a, --agent <name>      Target specific agent (can be repeated)");
-    println!("  -g, --global            Install to home directory (~/.agent/skills/)");
+    println!("  -g, --global            Install to home directory (~/.<agent>/skills/).");
+    println!("                          Also accepted for local-path installs to symlink");
+    println!("                          the source straight into each agent's home dir.");
     println!("  -l, --local             Install to current directory (default, uses symlinks)");
     println!("  -r, --ref               Install as a reference (README or SKILL.md) instead of a skill");
     println!("  -s, --skill <name>      For --ref: install a specific SKILL.md as the reference");
@@ -56,12 +58,14 @@ fn print_usage(prog: &str) {
     println!("  {prog} install owner/repo -a claude -a cursor");
     println!("  {prog} install owner/repo@v1.0.0");
     println!("  {prog} install ./skills/my-custom-skill   # symlink a local skill");
+    println!("  {prog} install ~/skills/my-skill -g       # symlink a local skill globally");
     println!("  {prog} install vercel/next.js --ref       # install README as a reference");
     println!("  {prog} install anthropics/skills --ref --skill pdf   # install a SKILL.md as a reference");
     println!("  {prog} install react --ref --npm                # symlink react's README + docs/ from node_modules");
     println!("  {prog} install @tanstack/react-query --ref --npm    # scoped npm package");
     println!("  {prog} install zod --ref --npm --include README.md  # only README");
     println!("  {prog} install                    # reinstall from .agents/rosie.lock");
+    println!("  {prog} install -g                 # reinstall from ~/.agents/rosie.lock");
     println!("  {prog} update                     # update all lockfile entries");
     println!("  {prog} update slack-gif-creator   # update one skill");
     println!("  {prog} list                       # show installed skills");

--- a/src/download.rs
+++ b/src/download.rs
@@ -96,10 +96,12 @@ fn looks_like_local_path(spec: &str) -> bool {
     false
 }
 
-/// Resolve a user-supplied path to a "./<rel>" form rooted at the current
-/// working directory. Expands a leading `~/`, canonicalizes via std::fs::
-/// canonicalize, rejects paths outside the cwd.
-fn canonicalize_local_path(user_path: &str) -> Option<String> {
+/// Resolve a user-supplied path. Expands a leading `~/` and canonicalizes via
+/// std::fs::canonicalize. For project installs (`global=false`) returns a
+/// `./<rel>` form rooted at the current working directory and rejects paths
+/// outside the cwd. For global installs returns the absolute path as-is so
+/// the source can live anywhere under `$HOME` (or elsewhere).
+fn canonicalize_local_path(user_path: &str, global: bool) -> Option<String> {
     if user_path.is_empty() {
         return None;
     }
@@ -123,6 +125,10 @@ fn canonicalize_local_path(user_path: &str) -> Option<String> {
             return None;
         }
     };
+
+    if global {
+        return Some(abs.to_string_lossy().into_owned());
+    }
 
     let cwd = match os::current_dir() {
         Ok(p) => p,
@@ -150,7 +156,7 @@ fn canonicalize_local_path(user_path: &str) -> Option<String> {
     }
 }
 
-pub fn parse(spec: &str) -> Option<PackageSpec> {
+pub fn parse(spec: &str, global: bool) -> Option<PackageSpec> {
     // Local-path / file:// shortcut.
     let local_input: Option<&str> = if source_is_local(spec) {
         source_local_path(spec)
@@ -160,7 +166,7 @@ pub fn parse(spec: &str) -> Option<PackageSpec> {
         None
     };
     if let Some(p) = local_input {
-        let canonical = canonicalize_local_path(p)?;
+        let canonical = canonicalize_local_path(p, global)?;
         return Some(PackageSpec {
             owner: None,
             repo: None,
@@ -285,7 +291,7 @@ mod tests {
 
     #[test]
     fn parse_basic() {
-        let s = parse("foo/bar").unwrap();
+        let s = parse("foo/bar", false).unwrap();
         assert_eq!(s.owner.as_deref(), Some("foo"));
         assert_eq!(s.repo.as_deref(), Some("bar"));
         assert_eq!(s.ref_.as_deref(), Some("main"));
@@ -294,14 +300,14 @@ mod tests {
 
     #[test]
     fn parse_pinned() {
-        let s = parse("foo/bar@v1.0.0").unwrap();
+        let s = parse("foo/bar@v1.0.0", false).unwrap();
         assert_eq!(s.ref_.as_deref(), Some("v1.0.0"));
         assert!(s.ref_explicit);
     }
 
     #[test]
     fn parse_with_skill() {
-        let s = parse("foo/bar#my-skill@main").unwrap();
+        let s = parse("foo/bar#my-skill@main", false).unwrap();
         assert_eq!(s.ref_.as_deref(), Some("main"));
         assert!(s.ref_explicit);
         assert_eq!(s.skill_in_spec.as_deref(), Some("my-skill"));
@@ -310,7 +316,7 @@ mod tests {
     #[test]
     fn parse_invalid() {
         crate::log::clear_last_error();
-        assert!(parse("foo").is_none());
+        assert!(parse("foo", false).is_none());
         assert!(crate::log::last_error_message().is_some());
     }
 
@@ -326,7 +332,7 @@ mod tests {
 
     #[test]
     fn url_build() {
-        let spec = parse("vercel/next.js@v14.0.0").unwrap();
+        let spec = parse("vercel/next.js@v14.0.0", false).unwrap();
         // Use a deterministic base URL for the test.
         std::env::set_var("ROSIE_GITHUB_BASE_URL", "https://example.test");
         assert_eq!(

--- a/src/install.rs
+++ b/src/install.rs
@@ -27,6 +27,24 @@ pub const LOCAL_AGENTS_DIR: &str = ".agents";
 pub const LOCAL_SKILLS_DIR: &str = ".agents/skills";
 pub const LOCAL_REFERENCES_DIR: &str = ".agents/references";
 
+// Subdirectory under `$HOME` for the global lockfile. Mirrors the project
+// `.agents/` layout — only `rosie.lock` lives here today; no canonical skills
+// or references dir, since global installs symlink agent dirs directly at the
+// source path with no intermediate hop.
+pub const GLOBAL_AGENTS_SUBDIR: &str = ".agents";
+
+/// Directory that holds `rosie.lock` for the given scope. Returns the
+/// project-relative `.agents` for `global=false`, and `$HOME/.agents` for
+/// `global=true`. Returns None if `$HOME` is unset under `global=true`.
+pub fn lockfile_dir(global: bool) -> Option<PathBuf> {
+    if global {
+        let home = os::home_dir()?;
+        Some(PathBuf::from(home).join(GLOBAL_AGENTS_SUBDIR))
+    } else {
+        Some(PathBuf::from(LOCAL_AGENTS_DIR))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Options structs — mirror InstallOptions / RemoveOptions in install.h.
 // ---------------------------------------------------------------------------
@@ -174,9 +192,11 @@ pub fn install_skill_to_agent(skill: &Skill, agent: &Agent, opts: &InstallOption
 ///
 /// When an agent's project path *is* the canonical store (`.agents/skills`),
 /// no symlink is needed — the skill already lives where the agent looks.
-/// For other agents, build a relative `../../...` prefix with one `..` per
-/// path component in `agent.install_path` so the link is correct for any
-/// install depth (e.g. `.tabnine/agent/skills` needs three).
+/// For project installs (relative `canonical_path`), build a relative
+/// `../../...` prefix with one `..` per path component in `agent.install_path`
+/// so the link is correct for any install depth (e.g. `.tabnine/agent/skills`
+/// needs three). For global installs (absolute `canonical_path`), link
+/// directly with no rewriting.
 fn install_skill_local(skill_name: &str, agent: &Agent, canonical_path: &Path) -> i32 {
     if agent.install_path.as_path() == Path::new(LOCAL_SKILLS_DIR) {
         return 0;
@@ -202,22 +222,26 @@ fn install_skill_local(skill_name: &str, agent: &Agent, canonical_path: &Path) -
             _ => {}
         }
     }
-    let depth = agent
-        .install_path
-        .components()
-        .filter(|c| matches!(c, std::path::Component::Normal(_)))
-        .count();
-    let mut prefix = String::new();
-    for _ in 0..depth {
-        prefix.push_str("../");
-    }
-    let relative_target = PathBuf::from(format!("{}{}", prefix, canonical_path.display()));
+    let target = if canonical_path.is_absolute() {
+        canonical_path.to_path_buf()
+    } else {
+        let depth = agent
+            .install_path
+            .components()
+            .filter(|c| matches!(c, std::path::Component::Normal(_)))
+            .count();
+        let mut prefix = String::new();
+        for _ in 0..depth {
+            prefix.push_str("../");
+        }
+        PathBuf::from(format!("{}{}", prefix, canonical_path.display()))
+    };
     crate::log::debug(&format!(
         "Symlink: {} -> {}",
         link_path.display(),
-        relative_target.display()
+        target.display()
     ));
-    rosie_create_link(&relative_target, &link_path, true)
+    rosie_create_link(&target, &link_path, true)
 }
 
 fn install_to_canonical(skill: &Skill, opts: &InstallOptions) -> Option<PathBuf> {
@@ -246,10 +270,6 @@ fn install_to_canonical(skill: &Skill, opts: &InstallOptions) -> Option<PathBuf>
 // ---------------------------------------------------------------------------
 
 fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
-    if opts.global {
-        crate::log::error("Local skills cannot be installed globally; drop --global");
-        return -1;
-    }
     let canonical_path = PathBuf::from(canonical_rel);
     if !os::is_dir(&canonical_path) {
         crate::log::error(&format!("Local skill directory not found: {canonical_rel}"));
@@ -280,9 +300,9 @@ fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
 
     let agents = if !opts.agent_names.is_empty() {
         let names: Vec<&str> = opts.agent_names.iter().map(String::as_str).collect();
-        agent::agents_from_names(&names, false)
+        agent::agents_from_names(&names, opts.global)
     } else {
-        agent::detect_agents(false)
+        agent::detect_agents(opts.global)
     };
     if agents.is_empty() {
         crate::log::error("No agents detected. Use --agent to specify target agent.");
@@ -295,12 +315,26 @@ fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
         return 0;
     }
 
+    // Choose the link target each per-agent symlink will point at. For project
+    // installs, agent symlinks hop through the canonical `.agents/skills/<name>`
+    // so retargeting only touches one place. For global installs, there is no
+    // canonical store — agent symlinks point directly at the absolute source.
+    let link_target = if opts.global {
+        PathBuf::from(canonical_rel)
+    } else {
+        PathBuf::from(LOCAL_SKILLS_DIR).join(&skill.name)
+    };
+
     if !opts.yes {
+        let target_label = if opts.global {
+            canonical_rel.to_string()
+        } else {
+            format!("{LOCAL_SKILLS_DIR}/{}", skill.name)
+        };
         let prompt = format!(
-            "\nLink {} -> {}/{} for {} agent(s)? [Y/n] ",
+            "\nLink {} -> {} for {} agent(s)? [Y/n] ",
             canonical_rel,
-            LOCAL_SKILLS_DIR,
-            skill.name,
+            target_label,
             agents.len()
         );
         if !ask_yes_no(&prompt) {
@@ -309,59 +343,61 @@ fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
         }
     }
 
-    if let Err(e) = os::create_dir_all(Path::new(LOCAL_SKILLS_DIR)) {
-        crate::log::error(&format!("Cannot create directory: {LOCAL_SKILLS_DIR}: {e}"));
-        return -1;
-    }
-
-    // canonical symlink target: ../../<canonical_rel_without_./>
-    let rel_for_link = canonical_rel.strip_prefix("./").unwrap_or(canonical_rel);
-    let canonical_target = if rel_for_link.is_empty() || rel_for_link == "." {
-        PathBuf::from("../..")
-    } else {
-        PathBuf::from(format!("../../{rel_for_link}"))
-    };
-    let canonical_link = PathBuf::from(LOCAL_SKILLS_DIR).join(&skill.name);
-
-    match os::symlink_metadata(&canonical_link) {
-        Ok(m) if m.kind == os::FileKind::Symlink => {
-            let existing = os::read_link(&canonical_link).unwrap_or_default();
-            if existing == canonical_target.to_string_lossy() {
-                crate::log::debug(&format!(
-                    "Canonical symlink already correct: {}",
-                    canonical_link.display()
-                ));
-            } else if os::remove_file(&canonical_link).is_err()
-                || rosie_create_link(&canonical_target, &canonical_link, true) != 0
-            {
-                return -1;
-            }
-        }
-        Ok(_) => {
-            crate::log::error(&format!(
-                "Refusing to overwrite existing non-symlink at {}",
-                canonical_link.display()
-            ));
+    if !opts.global {
+        if let Err(e) = os::create_dir_all(Path::new(LOCAL_SKILLS_DIR)) {
+            crate::log::error(&format!("Cannot create directory: {LOCAL_SKILLS_DIR}: {e}"));
             return -1;
         }
-        Err(_) => {
-            if rosie_create_link(&canonical_target, &canonical_link, true) != 0 {
+
+        // canonical symlink target: ../../<canonical_rel_without_./>
+        let rel_for_link = canonical_rel.strip_prefix("./").unwrap_or(canonical_rel);
+        let canonical_target = if rel_for_link.is_empty() || rel_for_link == "." {
+            PathBuf::from("../..")
+        } else {
+            PathBuf::from(format!("../../{rel_for_link}"))
+        };
+        let canonical_link = &link_target;
+
+        match os::symlink_metadata(canonical_link) {
+            Ok(m) if m.kind == os::FileKind::Symlink => {
+                let existing = os::read_link(canonical_link).unwrap_or_default();
+                if existing == canonical_target.to_string_lossy() {
+                    crate::log::debug(&format!(
+                        "Canonical symlink already correct: {}",
+                        canonical_link.display()
+                    ));
+                } else if os::remove_file(canonical_link).is_err()
+                    || rosie_create_link(&canonical_target, canonical_link, true) != 0
+                {
+                    return -1;
+                }
+            }
+            Ok(_) => {
+                crate::log::error(&format!(
+                    "Refusing to overwrite existing non-symlink at {}",
+                    canonical_link.display()
+                ));
                 return -1;
             }
+            Err(_) => {
+                if rosie_create_link(&canonical_target, canonical_link, true) != 0 {
+                    return -1;
+                }
+            }
         }
-    }
 
-    crate::log::info(&format!(
-        "  {} -> {}",
-        canonical_link.display(),
-        canonical_target.display()
-    ));
+        crate::log::info(&format!(
+            "  {} -> {}",
+            canonical_link.display(),
+            canonical_target.display()
+        ));
+    }
 
     let mut linked = 0;
     let mut ok_agents = Vec::new();
     let mut fail_agents = Vec::new();
     for a in &agents {
-        if install_skill_local(&skill.name, a, &canonical_link) == 0 {
+        if install_skill_local(&skill.name, a, &link_target) == 0 {
             linked += 1;
             ok_agents.push(a.def.name.to_string());
         } else {
@@ -377,7 +413,18 @@ fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
     });
 
     if !opts.skip_lockfile {
-        let mut lf = Lockfile::load(Path::new(LOCAL_AGENTS_DIR));
+        let Some(lf_dir) = lockfile_dir(opts.global) else {
+            crate::log::error("Cannot determine home directory for global lockfile");
+            return -1;
+        };
+        if let Err(e) = os::create_dir_all(&lf_dir) {
+            crate::log::error(&format!(
+                "Cannot create directory: {} ({e})",
+                lf_dir.display()
+            ));
+            return -1;
+        }
+        let mut lf = Lockfile::load(&lf_dir);
         let now = lockfile::now_iso8601();
         let source = format!("file://{canonical_rel}");
         lf.upsert(&skill.name, &source, "-", "-", &now, true, LockKind::Skill);
@@ -730,7 +777,7 @@ pub fn install_package(opts: &InstallOptions) -> i32 {
         return install_npm_references(opts);
     }
 
-    let mut spec = match download::parse(spec_str) {
+    let mut spec = match download::parse(spec_str, opts.global) {
         Some(s) => s,
         None => return -1,
     };
@@ -1165,7 +1212,11 @@ fn build_spec_string(source: &str, ref_: &str) -> String {
 // ---------------------------------------------------------------------------
 
 pub fn install_from_lockfile(base_opts: &InstallOptions) -> i32 {
-    let lf = Lockfile::load(Path::new(LOCAL_AGENTS_DIR));
+    let Some(lf_dir) = lockfile_dir(base_opts.global) else {
+        crate::log::error("Cannot determine home directory for global lockfile");
+        return 1;
+    };
+    let lf = Lockfile::load(&lf_dir);
     if lf.entries.is_empty() {
         crate::log::error(&format!(
             "No lockfile entries to install ({})",
@@ -1183,6 +1234,17 @@ pub fn install_from_lockfile(base_opts: &InstallOptions) -> i32 {
     let (mut ok, mut fail, mut fresh, mut present) = (0, 0, 0, 0);
 
     for e in &snap {
+        // v1 scope: the global lockfile only tracks local skill installs.
+        // Skip anything else with a warning rather than recursing into
+        // download / ref-install machinery that hasn't been wired through.
+        if base_opts.global && !source_is_local(&e.source) {
+            crate::log::info(&format!(
+                "warning: {}: --global only supports local skill installs, skipping ({})",
+                e.skill_name, e.source
+            ));
+            continue;
+        }
+
         // npm: refs are symlinks into node_modules/. Recreate the single
         // symlink for this entry. No version refresh (`rosie update` does that).
         if source_is_npm(&e.source) {
@@ -1231,7 +1293,7 @@ pub fn install_from_lockfile(base_opts: &InstallOptions) -> i32 {
                 skill_name: Some(e.skill_name.clone()),
                 yes: true,
                 list_only: false,
-                global: false,
+                global: base_opts.global,
                 override_pinned: false,
                 pinned: false,
                 ..base_opts.clone()
@@ -1337,9 +1399,12 @@ pub fn install_from_lockfile(base_opts: &InstallOptions) -> i32 {
         }
     }
 
-    // Refresh AGENTS.md from final lockfile state.
-    let lf_final = Lockfile::load(Path::new(LOCAL_AGENTS_DIR));
-    let _ = agentsmd::rebuild_block(&lf_final);
+    // Refresh AGENTS.md from final lockfile state. Global installs don't
+    // touch a user-level AGENTS.md / CLAUDE.md, so skip for `--global`.
+    if !base_opts.global {
+        let lf_final = Lockfile::load(Path::new(LOCAL_AGENTS_DIR));
+        let _ = agentsmd::rebuild_block(&lf_final);
+    }
 
     if fail > 0 {
         crate::log::error(&format!(
@@ -1557,7 +1622,7 @@ pub fn update_skills(base_opts: &InstallOptions, only_skill: Option<&str>) -> i3
             continue;
         }
 
-        let ps = match download::parse(&e.source) {
+        let ps = match download::parse(&e.source, false) {
             Some(p) => p,
             None => {
                 crate::log::error(&format!("update: cannot parse source '{}'", e.source));

--- a/tests/regression/cases/install-from-lockfile-global/assertions.sh
+++ b/tests/regression/cases/install-from-lockfile-global/assertions.sh
@@ -1,0 +1,14 @@
+assert_exit_code 0 "$(cat exit_code)"
+assert_contains stdout "Reinstalling 1 skill(s) from lockfile"
+# file:// entries count as `ok` but not `fresh`, so reinstall reports the
+# "already installed" wording even though the symlink is freshly created.
+assert_contains stdout "Linking local skill: my-global-skill"
+
+# Reinstall recreates the per-agent symlink pointing at the absolute source.
+assert_symlink_target "$HOME/.claude/skills/my-global-skill" "$HOME/my-global-skill"
+
+# Lockfile must remain at ~/.agents/rosie.lock (no project lockfile created).
+assert_file_exists "$HOME/.agents/rosie.lock"
+if [ -d ".agents" ]; then
+    _fail ".agents/ should not exist for a --global reinstall"
+fi

--- a/tests/regression/cases/install-from-lockfile-global/run.sh
+++ b/tests/regression/cases/install-from-lockfile-global/run.sh
@@ -1,0 +1,27 @@
+# install-from-lockfile-global: `rosie install -g` with no args reinstalls
+# from ~/.agents/rosie.lock. Pre-seed the global lockfile with a file://
+# entry pointing at a staged source, then run.
+
+mkdir -p "$HOME/.claude"
+
+# Stage the source the lockfile points at.
+mkdir -p "$HOME/my-global-skill"
+cat > "$HOME/my-global-skill/SKILL.md" <<'EOF'
+---
+name: my-global-skill
+description: A local skill installed globally for the regression test
+---
+
+# my-global-skill
+
+Body.
+EOF
+
+mkdir -p "$HOME/.agents"
+cat > "$HOME/.agents/rosie.lock" <<EOF
+# rosie-lock v1
+my-global-skill file://$HOME/my-global-skill - - 2025-01-01T00:00:00Z pin skill
+EOF
+
+"$ROSIE" install -g -y > stdout 2> stderr
+echo $? > exit_code

--- a/tests/regression/cases/install-local-path-global/assertions.sh
+++ b/tests/regression/cases/install-local-path-global/assertions.sh
@@ -1,0 +1,15 @@
+assert_exit_code 0 "$(cat exit_code)"
+assert_contains stdout "Linking local skill"
+assert_contains stdout "my-global-skill"
+
+# No canonical hop globally: the agent symlink points straight at the source.
+assert_symlink_target "$HOME/.claude/skills/my-global-skill" "$HOME/my-global-skill"
+
+# Global install must not create a project canonical store.
+if [ -d ".agents" ]; then
+    _fail ".agents/ should not exist for a --global local install"
+fi
+
+# Lockfile lives at ~/.agents/rosie.lock with a file:// source.
+assert_file_exists "$HOME/.agents/rosie.lock"
+assert_contains "$HOME/.agents/rosie.lock" "file://$HOME/my-global-skill"

--- a/tests/regression/cases/install-local-path-global/assertions.sh
+++ b/tests/regression/cases/install-local-path-global/assertions.sh
@@ -2,8 +2,12 @@ assert_exit_code 0 "$(cat exit_code)"
 assert_contains stdout "Linking local skill"
 assert_contains stdout "my-global-skill"
 
+# rosie stores the canonicalized source path (std::fs::canonicalize), and on
+# macOS that resolves /var -> /private/var. Match against the realpath form.
+REAL_HOME="$(cd "$HOME" && pwd -P)"
+
 # No canonical hop globally: the agent symlink points straight at the source.
-assert_symlink_target "$HOME/.claude/skills/my-global-skill" "$HOME/my-global-skill"
+assert_symlink_target "$HOME/.claude/skills/my-global-skill" "$REAL_HOME/my-global-skill"
 
 # Global install must not create a project canonical store.
 if [ -d ".agents" ]; then
@@ -12,4 +16,4 @@ fi
 
 # Lockfile lives at ~/.agents/rosie.lock with a file:// source.
 assert_file_exists "$HOME/.agents/rosie.lock"
-assert_contains "$HOME/.agents/rosie.lock" "file://$HOME/my-global-skill"
+assert_contains "$HOME/.agents/rosie.lock" "file://$REAL_HOME/my-global-skill"

--- a/tests/regression/cases/install-local-path-global/run.sh
+++ b/tests/regression/cases/install-local-path-global/run.sh
@@ -1,0 +1,23 @@
+# install-local-path-global: install a local-path skill with --global.
+# The source can live anywhere (outside the project tree), agent symlinks
+# point directly at the absolute source path (no canonical .agents/skills
+# hop), and the lockfile is written to ~/.agents/rosie.lock.
+
+mkdir -p "$HOME/.claude"
+
+# Stage a local skill OUTSIDE the project tree so we exercise the
+# global-only path-canonicalisation (no "outside the project" rejection).
+mkdir -p "$HOME/my-global-skill"
+cat > "$HOME/my-global-skill/SKILL.md" <<'EOF'
+---
+name: my-global-skill
+description: A local skill installed globally for the regression test
+---
+
+# my-global-skill
+
+Body.
+EOF
+
+"$ROSIE" install -g -y "$HOME/my-global-skill" > stdout 2> stderr
+echo $? > exit_code

--- a/website/src/content/docs/cli.md
+++ b/website/src/content/docs/cli.md
@@ -58,7 +58,7 @@ $ rosie install owner/repo -y
   <h3 class="sub-label">flags</h3>
   <ul class="bullet-list">
     <li><span class="bullet">▸</span><strong class="key">-a, --agent &lt;name&gt;</strong><span class="val">install to a specific agent (repeatable)</span></li>
-    <li><span class="bullet">▸</span><strong class="key">-g, --global</strong><span class="val">install globally to <code>~/.&lt;agent&gt;/skills/</code> (copies files)</span></li>
+    <li><span class="bullet">▸</span><strong class="key">-g, --global</strong><span class="val">install globally to <code>~/.&lt;agent&gt;/skills/</code> · GitHub sources are copied · local paths are symlinked in place</span></li>
     <li><span class="bullet">▸</span><strong class="key">-l, --local</strong><span class="val">install locally with symlinks (default)</span></li>
     <li><span class="bullet">▸</span><strong class="key">-r, --ref</strong><span class="val">install as a reference (README, or a SKILL.md via <code>--skill</code>)</span></li>
     <li><span class="bullet">▸</span><strong class="key">-s, --skill &lt;name&gt;</strong><span class="val">with <code>--ref</code>: install a specific SKILL.md</span></li>
@@ -83,7 +83,7 @@ $ rosie install owner/repo -y
     <li>
       <span class="bullet">▸</span>
       <strong class="key">global (<code>--global</code>)</strong>
-      <span class="val">files copied directly into <code>~/.&lt;agent&gt;/skills/&lt;name&gt;/</code> for every detected agent. shared across projects, no lockfile, no symlinks.</span>
+      <span class="val">installs into <code>~/.&lt;agent&gt;/skills/&lt;name&gt;/</code> for every detected agent. shared across projects. GitHub sources are copied (no lockfile). local paths (<code>rosie install ~/skills/my-skill -g</code>) are symlinked directly at the source and tracked in <code>~/.agents/rosie.lock</code> — re-run with no args to re-link after a machine wipe.</span>
     </li>
   </ul>
 </section>

--- a/website/src/content/docs/how-it-works.md
+++ b/website/src/content/docs/how-it-works.md
@@ -31,7 +31,8 @@ navOrder: 9
    │
    └─▶ install
        local:  copy to .agents/skills/, symlink to each agent
-       global: copy directly to each ~/.&lt;agent&gt;/skills/</pre>
+       global: copy directly to each ~/.&lt;agent&gt;/skills/
+               (local paths are symlinked in place, tracked in ~/.agents/rosie.lock)</pre>
 
   <ul class="bullet-list">
     <li>

--- a/website/src/content/docs/lockfile.md
+++ b/website/src/content/docs/lockfile.md
@@ -48,7 +48,7 @@ navOrder: 2
     <li>
       <span class="bullet">▸</span>
       <strong class="key">file://</strong>
-      <span class="val"><code>rosie install ./my-skill</code> writes a <code>file://</code> source · hand-authored skills in your repo travel with it</span>
+      <span class="val"><code>rosie install ./my-skill</code> writes a <code>file://</code> source · hand-authored skills in your repo travel with it · with <code>--global</code>, the same form lands in <code>~/.agents/rosie.lock</code> with an absolute path</span>
     </li>
     <li>
       <span class="bullet">▸</span>


### PR DESCRIPTION
## Summary
- `rosie install ~/skills/foo -g` symlinks the source straight into each detected agent's home dir (e.g. `~/.claude/skills/foo`) and records a `file://` entry in a new `~/.agents/rosie.lock`.
- `rosie install -g` with no args reinstalls from that global lockfile, so a fresh machine + dotfiles checkout can restore every globally-installed local skill in one command.
- Project-scope install / reinstall behavior is unchanged.

## Why
The current message — "Local skills cannot be installed globally; drop --global" — was a conservative early-exit, not a real limitation. The plumbing was already 90% there: `agent::install_path(def, global)` already returned `$HOME/.claude/skills` under `--global`, and `install_skill_local` already symlinked into whatever path the agent gave it. This PR removes the early-exit and adds the missing pieces: an absolute-target branch in `install_skill_local`, a `--global`-aware `canonicalize_local_path` (skips the "outside the project" check), and a `lockfile_dir(global)` helper so the lockfile lives at `~/.agents/rosie.lock` for global installs.

## Scope
Skills only for v1. `--ref --global` is still rejected (unchanged). The global reinstall path skips non-local lockfile entries with a warning rather than recursing into the GitHub / npm / ref machinery. Follow-up PR can thread `--global` through `remove` / `list` / `update`.

## Test plan
- [x] `cargo test` — 54 unit tests pass
- [x] `tests/regression/run.sh` — 50/50 cases pass (48 existing + 2 new)
- [x] New regression: `install-local-path-global` — `rosie install -g ~/my-skill` creates the absolute symlink, doesn't touch `.agents/`, writes `~/.agents/rosie.lock`
- [x] New regression: `install-from-lockfile-global` — `rosie install -g` (no args) re-links from `~/.agents/rosie.lock`
- [ ] Manual: try it on a real machine with `~/skills/` populated