### PR TITLE
Fix misleading --global prompt for local-path installs

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -326,17 +326,21 @@ fn install_local(canonical_rel: &str, opts: &InstallOptions) -> i32 {
     };
 
     if !opts.yes {
-        let target_label = if opts.global {
-            canonical_rel.to_string()
+        let prompt = if opts.global {
+            format!(
+                "\nSymlink {} into {} agent(s)' global skills/ dir? [Y/n] ",
+                canonical_rel,
+                agents.len()
+            )
         } else {
-            format!("{LOCAL_SKILLS_DIR}/{}", skill.name)
+            format!(
+                "\nLink {} -> {}/{} for {} agent(s)? [Y/n] ",
+                canonical_rel,
+                LOCAL_SKILLS_DIR,
+                skill.name,
+                agents.len()
+            )
         };
-        let prompt = format!(
-            "\nLink {} -> {} for {} agent(s)? [Y/n] ",
-            canonical_rel,
-            target_label,
-            agents.len()
-        );
         if !ask_yes_no(&prompt) {
             crate::log::info("Cancelled.");
             return 0;


### PR DESCRIPTION
## Summary
The confirmation prompt for `rosie install <path> -g` was printing
`Link /home/matthew/skills/foo -> /home/matthew/skills/foo for 3 agent(s)?` — same path on both sides because the global branch reused `canonical_rel` as the right-hand label. Cosmetic-only; the underlying symlinks were always correct.

Now the prompt branches by scope:

- **global**: `Symlink /home/matthew/skills/foo into 3 agent(s)' global skills/ dir? [Y/n]`
- **project**: `Link ./my-skill -> .agents/skills/my-skill for 3 agent(s)? [Y/n]` (unchanged)

## Test plan
- [x] `cargo test` — 54 unit tests pass
- [x] `tests/regression/run.sh` — all 50 cases pass
- [x] Manually verified both prompt strings against the release binary