### PR TITLE
Support `rosie list -g` for global lockfile

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,7 +265,7 @@ fn cmd_install(prog: &str, args: Vec<std::ffi::OsString>, list_only: bool) -> i3
 
     if positional.is_empty() {
         if list_only {
-            return install::list_installed_skills();
+            return install::list_installed_skills(opts.global);
         }
         let rc = install::install_from_lockfile(&opts);
         emit_audit_if_appropriate(&opts);

--- a/src/install.rs
+++ b/src/install.rs
@@ -1735,18 +1735,29 @@ pub fn update_skills(base_opts: &InstallOptions, only_skill: Option<&str>) -> i3
 // list_installed_skills
 // ---------------------------------------------------------------------------
 
-pub fn list_installed_skills() -> i32 {
-    let lf = Lockfile::load(Path::new(LOCAL_AGENTS_DIR));
+pub fn list_installed_skills(global: bool) -> i32 {
+    let Some(lf_dir) = lockfile_dir(global) else {
+        crate::log::error("Cannot determine home directory for global lockfile");
+        return 1;
+    };
+    let lf = Lockfile::load(&lf_dir);
     if lf.entries.is_empty() {
+        let scope = if global { "globally" } else { "in this project" };
         println!(
-            "No skills installed in this project ({} not found or empty)",
+            "No skills installed {scope} ({} not found or empty)",
             lf.path.display()
         );
-        println!("Install with: rosie install <owner/repo>");
+        let install_hint = if global {
+            "Install with: rosie install <owner/repo> -g"
+        } else {
+            "Install with: rosie install <owner/repo>"
+        };
+        println!("{install_hint}");
         return 0;
     }
     let use_color = is_stdout_tty();
-    println!("Installed skills ({}):", lf.path.display());
+    let header_scope = if global { "global " } else { "" };
+    println!("Installed {header_scope}skills ({}):", lf.path.display());
     for e in &lf.entries {
         let kind_tag = if e.kind == LockKind::Ref { "[ref]  " } else { "[skill]" };
         let (name_open, name_close) = if use_color {

--- a/tests/regression/cases/list-global-empty/assertions.sh
+++ b/tests/regression/cases/list-global-empty/assertions.sh
@@ -1,0 +1,5 @@
+assert_exit_code 0 "$(cat exit_code)"
+assert_contains stdout "No skills installed globally"
+assert_contains stdout ".agents/rosie.lock"
+assert_contains stdout "rosie install <owner/repo> -g"
+assert_not_contains stdout "this project"

--- a/tests/regression/cases/list-global-empty/run.sh
+++ b/tests/regression/cases/list-global-empty/run.sh
@@ -1,0 +1,5 @@
+# list-global-empty: `rosie list -g` with no global lockfile should print
+# the empty-state hint, not the project-scoped wording.
+
+"$ROSIE" list -g > stdout 2> stderr
+echo $? > exit_code

--- a/tests/regression/cases/list-global/assertions.sh
+++ b/tests/regression/cases/list-global/assertions.sh
@@ -1,0 +1,9 @@
+assert_exit_code 0 "$(cat exit_code)"
+assert_contains stdout "Installed global skills"
+assert_contains stdout "my-global-skill"
+assert_contains stdout "[skill]"
+assert_contains stdout "(linked)"
+
+# The header should point at the global lockfile, not the project one.
+assert_contains stdout ".agents/rosie.lock"
+assert_not_contains stdout "this project"

--- a/tests/regression/cases/list-global/run.sh
+++ b/tests/regression/cases/list-global/run.sh
@@ -1,0 +1,21 @@
+# list-global: install a local skill with -g, then `rosie list -g`
+# should print it from ~/.agents/rosie.lock.
+
+mkdir -p "$HOME/.claude"
+
+mkdir -p "$HOME/my-global-skill"
+cat > "$HOME/my-global-skill/SKILL.md" <<'EOF'
+---
+name: my-global-skill
+description: A local skill installed globally for the regression test
+---
+
+# my-global-skill
+
+Body.
+EOF
+
+"$ROSIE" install -g -y "$HOME/my-global-skill" > /dev/null 2>&1
+
+"$ROSIE" list -g > stdout 2> stderr
+echo $? > exit_code


### PR DESCRIPTION
## Summary
Following the `--global` local-install work in #16, this adds `rosie list -g` so you can see what lives in `~/.agents/rosie.lock` without `cat`-ing the file yourself.

```
$ rosie list -g
Installed global skills (/home/matthew/.agents/rosie.lock):
  [skill]  homelab-services        /home/matthew/skills/homelab-services        (linked)
  [skill]  skill-creator           /home/matthew/skills/skill-creator           (linked)
  [skill]  update-lyceum           /home/matthew/skills/update-lyceum           (linked)
  [skill]  web-design-guidelines   /home/matthew/skills/web-design-guidelines   (linked)
```

Empty state under `-g` also drops the "this project" wording and points the user at `rosie install <owner/repo> -g`.

## Implementation
- `list_installed_skills(global: bool)` loads from `lockfile_dir(global)` (the helper added in #16) instead of hard-coded `LOCAL_AGENTS_DIR`.
- Header and empty-state strings branch on scope.
- `cli.rs` passes `opts.global` through.

## Test plan
- [x] `cargo test` — 54 unit tests pass
- [x] `tests/regression/run.sh` — 52/52 cases pass (50 prior + 2 new)
- [x] New regression: `list-global` — `rosie list -g` prints the seeded entry
- [x] New regression: `list-global-empty` — empty case prints the global hint
- [x] Manually smoke-tested both populated and empty output against the release binary