### PR TITLE
Show basename instead of full path in CLI usage/help

### DIFF
--- a/npm/rosie-skills/src/cli.ts
+++ b/npm/rosie-skills/src/cli.ts
@@ -5,6 +5,7 @@
 // negative return to 255.
 
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { parseArgs } from "node:util";
 import * as agent from "./agent.js";
 import * as audit from "./audit.js";
@@ -162,12 +163,16 @@ export async function run(args: string[]): Promise<number> {
   const raw = applyCwd(args);
   if (raw === null) return 1;
 
+  // Display name in usage/help/examples. argv[0] is often a full path (e.g. the
+  // npx bin shim at ~/.npm/_npx/.../node_modules/.bin/rosie-skills); show just
+  // the basename so help reads `rosie-skills` regardless of how it was invoked.
+  const prog = raw.length > 0 ? path.basename(raw[0]) : "rosie-skills";
+
   if (raw.length < 2) {
-    printUsage("rosie");
+    printUsage(prog);
     return 1;
   }
 
-  const prog = raw[0];
   const command = raw[1];
   const cmdArgs = raw.slice(2);
 


### PR DESCRIPTION
## Problem

`npx rosie-skills --help` printed the full bin-shim path on every Usage and example line:

```
Usage: /home/matthew/.npm/_npx/0ada1327b5a9d3c8/node_modules/.bin/rosie-skills <command> ...
```

`prog` was set to `argv[0]`, which under npx is the full path to the resolved bin shim.

## Fix

Take the basename of `argv[0]` so help always reads `rosie-skills` regardless of how it was invoked. The no-arg usage (previously hardcoded `rosie`) now uses the same basename for consistency.

Scope is the npm/JS package only: the native Rust binary runs from PATH as `rosie`, so its `argv[0]` isn't a full path and it doesn't have this problem.

## Testing

- `tsc` build clean.
- Invoked under a `rosie-skills`-named path, help prints `Usage: rosie-skills <command> ...`.
- Regression suite: 52/52 pass in JS mode.