### PR TITLE
Drop the diff dependency for a local unified-diff generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,9 @@ jobs:
       - name: Build the pure-JS package
         run: cd npm/rosie-skills && npm install && npm run build
 
+      - name: Run pure-JS unit tests
+        run: cd npm/rosie-skills && node --test test/diff.test.mjs
+
       - name: Run regression suite (js)
         run: ./tests/regression/run.sh --mode js
 

--- a/npm/rosie-skills/package-lock.json
+++ b/npm/rosie-skills/package-lock.json
@@ -9,27 +9,19 @@
       "version": "0.0.0",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "diff": "^7.0.0",
         "modern-tar": "^0.7.6"
       },
       "bin": {
         "rosie-skills": "dist/bin.js"
       },
       "devDependencies": {
-        "@types/diff": "^7.0.0",
         "@types/node": "^20.0.0",
+        "diff": "^7.0.0",
         "typescript": "^5.4.0"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@types/diff": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.41",
@@ -45,6 +37,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
       "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/npm/rosie-skills/package.json
+++ b/npm/rosie-skills/package.json
@@ -17,7 +17,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "node --test test/diff.test.mjs"
   },
   "repository": {
     "type": "git",
@@ -30,12 +31,11 @@
     "node": ">=18"
   },
   "dependencies": {
-    "diff": "^7.0.0",
     "modern-tar": "^0.7.6"
   },
   "devDependencies": {
-    "@types/diff": "^7.0.0",
     "@types/node": "^20.0.0",
+    "diff": "^7.0.0",
     "typescript": "^5.4.0"
   }
 }

--- a/npm/rosie-skills/src/audit.ts
+++ b/npm/rosie-skills/src/audit.ts
@@ -6,7 +6,7 @@
 //
 // Threat model and schema rationale: see design/security.md.
 
-import { createTwoFilesPatch } from "diff";
+import { createUnifiedDiff } from "./unified-diff.js";
 
 export type Operation = "install" | "update";
 export type AuditKind = "skill" | "reference";
@@ -82,12 +82,11 @@ export function isEmpty(audit: Audit): boolean {
 
 // Build a unified-diff string for `name` between `old` and `new`, with 3 lines
 // of context. Empty string if both sides are equal. Mirrors
-// audit.rs::unified_diff (uses the `diff` package instead of `similar`).
+// audit.rs::unified_diff; uses the local ./unified-diff generator (an LCS-based
+// git-style unified diff) rather than a third-party diff package.
 export function unifiedDiff(name: string, oldStr: string, newStr: string): string {
   if (oldStr === newStr) return "";
-  return createTwoFilesPatch(`a/${name}`, `b/${name}`, oldStr, newStr, undefined, undefined, {
-    context: 3,
-  });
+  return createUnifiedDiff(`a/${name}`, `b/${name}`, oldStr, newStr, 3);
 }
 
 // Serialize an Audit to JSON. Field order matches audit.rs::to_json; JSON

--- a/npm/rosie-skills/src/unified-diff.ts
+++ b/npm/rosie-skills/src/unified-diff.ts
@@ -1,0 +1,226 @@
+// Minimal line-level unified-diff generator.
+//
+// Replaces the `diff` package's `createTwoFilesPatch` for the single use site
+// in audit.ts (the unified diff stored in the audit record on updates). The
+// diff is human/agent-facing review text, never machine-applied, so there is
+// no byte-for-byte contract with any other implementation.
+//
+// Algorithm: trim the common leading/trailing lines, then run a
+// longest-common-subsequence diff over just the region that actually changed.
+// Trimming keeps the O(n*m) table small for the common case (a localized edit
+// in a larger file); a size guard falls back to a wholesale region replacement
+// for pathological large rewrites that skill/reference files never hit.
+//
+// Lines retain their trailing newline, so a line missing one (only ever the
+// last line of a file) compares unequal to the same text with a newline and
+// gets a `\ No newline at end of file` marker. Output is git-style
+// (`--- a/x` / `+++ b/x` / `@@ -l,s +l,s @@`), which also matches the Rust
+// side's `similar`-based output more closely than the old format did.
+
+interface Op {
+  type: "eq" | "del" | "ins";
+  // Index into old lines for `eq`/`del` (-1 for `ins`).
+  a: number;
+  // Index into new lines for `eq`/`ins` (-1 for `del`).
+  b: number;
+}
+
+// Cap on the LCS table size (cells) after prefix/suffix trimming. Beyond this
+// the changed region is emitted as a wholesale delete+insert rather than
+// allocating an enormous table. Real skills/references never approach this.
+const MAX_CELLS = 4_000_000;
+
+const NO_NEWLINE = "\\ No newline at end of file";
+
+// Split into lines, each keeping its trailing "\n" except possibly the last.
+// An empty string is zero lines.
+function splitLines(s: string): string[] {
+  if (s === "") return [];
+  const out: string[] = [];
+  let start = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\n") {
+      out.push(s.slice(start, i + 1));
+      start = i + 1;
+    }
+  }
+  if (start < s.length) out.push(s.slice(start)); // last line, no newline
+  return out;
+}
+
+// LCS edit script over a[aLo, aHi) vs b[bLo, bHi), appended to `ops`.
+function lcsRegion(
+  a: string[],
+  b: string[],
+  aLo: number,
+  aHi: number,
+  bLo: number,
+  bHi: number,
+  ops: Op[],
+): void {
+  const n = aHi - aLo;
+  const m = bHi - bLo;
+  // dp[i][j] = LCS length of a[aLo+i..aHi) and b[bLo+j..bHi).
+  const dp: Int32Array[] = new Array(n + 1);
+  for (let i = 0; i <= n; i++) dp[i] = new Int32Array(m + 1);
+  for (let i = n - 1; i >= 0; i--) {
+    const ai = a[aLo + i];
+    const dpi = dp[i];
+    const dpi1 = dp[i + 1];
+    for (let j = m - 1; j >= 0; j--) {
+      if (ai === b[bLo + j]) dpi[j] = dpi1[j + 1] + 1;
+      else dpi[j] = dpi1[j] >= dpi[j + 1] ? dpi1[j] : dpi[j + 1];
+    }
+  }
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[aLo + i] === b[bLo + j]) {
+      ops.push({ type: "eq", a: aLo + i, b: bLo + j });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      ops.push({ type: "del", a: aLo + i, b: -1 });
+      i++;
+    } else {
+      ops.push({ type: "ins", a: -1, b: bLo + j });
+      j++;
+    }
+  }
+  while (i < n) {
+    ops.push({ type: "del", a: aLo + i, b: -1 });
+    i++;
+  }
+  while (j < m) {
+    ops.push({ type: "ins", a: -1, b: bLo + j });
+    j++;
+  }
+}
+
+function diffLines(a: string[], b: string[]): Op[] {
+  const ops: Op[] = [];
+  const n = a.length;
+  const m = b.length;
+
+  // Common prefix.
+  let lo = 0;
+  while (lo < n && lo < m && a[lo] === b[lo]) lo++;
+  // Common suffix (not overlapping the prefix).
+  let hiA = n;
+  let hiB = m;
+  while (hiA > lo && hiB > lo && a[hiA - 1] === b[hiB - 1]) {
+    hiA--;
+    hiB--;
+  }
+
+  for (let i = 0; i < lo; i++) ops.push({ type: "eq", a: i, b: i });
+
+  const midA = hiA - lo;
+  const midB = hiB - lo;
+  if (midA > 0 && midB === 0) {
+    for (let i = lo; i < hiA; i++) ops.push({ type: "del", a: i, b: -1 });
+  } else if (midB > 0 && midA === 0) {
+    for (let j = lo; j < hiB; j++) ops.push({ type: "ins", a: -1, b: j });
+  } else if (midA > 0 && midB > 0) {
+    if (midA * midB > MAX_CELLS) {
+      for (let i = lo; i < hiA; i++) ops.push({ type: "del", a: i, b: -1 });
+      for (let j = lo; j < hiB; j++) ops.push({ type: "ins", a: -1, b: j });
+    } else {
+      lcsRegion(a, b, lo, hiA, lo, hiB, ops);
+    }
+  }
+
+  for (let i = hiA; i < n; i++) ops.push({ type: "eq", a: i, b: i - hiA + hiB });
+  return ops;
+}
+
+function fmtRange(start: number, count: number): string {
+  return count === 1 ? `${start}` : `${start},${count}`;
+}
+
+// Old/new lines consumed before op index `start` (the preceding line number,
+// per GNU's convention for a zero-length range).
+function linesBefore(ops: Op[], start: number, side: "a" | "b"): number {
+  let c = 0;
+  for (let i = 0; i < start; i++) if (ops[i][side] >= 0) c++;
+  return c;
+}
+
+export function createUnifiedDiff(
+  oldName: string,
+  newName: string,
+  oldStr: string,
+  newStr: string,
+  context = 3,
+): string {
+  if (oldStr === newStr) return "";
+
+  const oldLines = splitLines(oldStr);
+  const newLines = splitLines(newStr);
+  const ops = diffLines(oldLines, newLines);
+
+  const changeIdx: number[] = [];
+  for (let i = 0; i < ops.length; i++) if (ops[i].type !== "eq") changeIdx.push(i);
+  // Equal line arrays imply equal strings, already handled above.
+  if (changeIdx.length === 0) return "";
+
+  // Group changes into hunks; merge groups separated by <= 2*context eq lines.
+  const groups: Array<[number, number]> = [];
+  let g = 0;
+  while (g < changeIdx.length) {
+    let end = g;
+    while (
+      end + 1 < changeIdx.length &&
+      changeIdx[end + 1] - changeIdx[end] - 1 <= 2 * context
+    ) {
+      end++;
+    }
+    const first = changeIdx[g];
+    const last = changeIdx[end];
+    groups.push([Math.max(0, first - context), Math.min(ops.length - 1, last + context)]);
+    g = end + 1;
+  }
+
+  const out: string[] = [];
+  out.push(`--- ${oldName}`);
+  out.push(`+++ ${newName}`);
+
+  const emit = (prefix: string, line: string): void => {
+    if (line.endsWith("\n")) {
+      out.push(prefix + line.slice(0, -1));
+    } else {
+      out.push(prefix + line);
+      out.push(NO_NEWLINE);
+    }
+  };
+
+  for (const [start, end] of groups) {
+    let oldCount = 0;
+    let newCount = 0;
+    let oldFirst = -1;
+    let newFirst = -1;
+    for (let i = start; i <= end; i++) {
+      const op = ops[i];
+      if (op.a >= 0) {
+        if (oldFirst < 0) oldFirst = op.a;
+        oldCount++;
+      }
+      if (op.b >= 0) {
+        if (newFirst < 0) newFirst = op.b;
+        newCount++;
+      }
+    }
+    const oldStart = oldCount === 0 ? linesBefore(ops, start, "a") : oldFirst + 1;
+    const newStart = newCount === 0 ? linesBefore(ops, start, "b") : newFirst + 1;
+    out.push(`@@ -${fmtRange(oldStart, oldCount)} +${fmtRange(newStart, newCount)} @@`);
+
+    for (let i = start; i <= end; i++) {
+      const op = ops[i];
+      if (op.type === "eq") emit(" ", oldLines[op.a]);
+      else if (op.type === "del") emit("-", oldLines[op.a]);
+      else emit("+", newLines[op.b]);
+    }
+  }
+
+  return out.join("\n") + "\n";
+}

--- a/npm/rosie-skills/test/diff.test.mjs
+++ b/npm/rosie-skills/test/diff.test.mjs
@@ -1,0 +1,200 @@
+// Tests for src/unified-diff.ts (compiled to dist/unified-diff.js).
+//
+// Run with `npm test` (builds first). Three layers of confidence:
+//   1. Correctness: apply our diff back onto `old` and require it to
+//      reconstruct `new` exactly, across thousands of fuzzed inputs.
+//   2. Minimality: compare our edit distance (adds + deletes) against the
+//      `diff` package's for the same inputs. Both are minimal, so the counts
+//      must match. `diff` is a devDependency kept solely for this check.
+//   3. Golden + edge cases: pin the exact output format and the boundaries
+//      (empty files, single line, no trailing newline, newline-only change).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createTwoFilesPatch } from "diff";
+
+import { createUnifiedDiff } from "../dist/unified-diff.js";
+
+// Apply a git-style unified diff produced by createUnifiedDiff back onto the
+// original string. Independent of the generator's internals so it is a real
+// cross-check, not a tautology.
+function applyUnified(oldStr, patch) {
+  if (patch === "") return oldStr;
+  const orig =
+    oldStr === "" ? [] : (oldStr.endsWith("\n") ? oldStr.slice(0, -1) : oldStr).split("\n");
+  const plines = patch.endsWith("\n") ? patch.slice(0, -1).split("\n") : patch.split("\n");
+
+  const out = [];
+  let oldPos = 0; // 0-based index into orig
+  let resultFinalNewline = true;
+
+  let i = 0;
+  while (i < plines.length && !plines[i].startsWith("@@")) i++; // skip ---/+++
+
+  while (i < plines.length) {
+    const header = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/.exec(plines[i]);
+    assert.ok(header, `bad hunk header: ${plines[i]}`);
+    const oldStart = parseInt(header[1], 10);
+    const oldCount = header[2] === undefined ? 1 : parseInt(header[2], 10);
+    const hunkOldStart = oldCount === 0 ? oldStart : oldStart - 1; // 0-based
+    while (oldPos < hunkOldStart) out.push(orig[oldPos++]);
+    i++;
+
+    let prevTag = null;
+    while (i < plines.length && !plines[i].startsWith("@@")) {
+      const line = plines[i];
+      if (line === "\\ No newline at end of file") {
+        if (prevTag === "+" || prevTag === " ") resultFinalNewline = false;
+        i++;
+        continue;
+      }
+      const tag = line[0];
+      const content = line.slice(1);
+      if (tag === " ") {
+        out.push(content);
+        oldPos++;
+      } else if (tag === "-") {
+        oldPos++;
+      } else if (tag === "+") {
+        out.push(content);
+      } else {
+        assert.fail(`bad body line: ${line}`);
+      }
+      prevTag = tag;
+      i++;
+    }
+  }
+  while (oldPos < orig.length) out.push(orig[oldPos++]);
+
+  let res = out.join("\n");
+  if (out.length > 0 && resultFinalNewline) res += "\n";
+  return res;
+}
+
+// Count +/- body lines, ignoring the ---/+++ headers. Works for both our
+// output and `diff`'s.
+function editCount(patch) {
+  let adds = 0;
+  let dels = 0;
+  for (const line of patch.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) adds++;
+    else if (line.startsWith("-")) dels++;
+  }
+  return adds + dels;
+}
+
+// Deterministic PRNG (mulberry32) so failures reproduce.
+function rng(seed) {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomFile(rand) {
+  const n = Math.floor(rand() * 12); // 0..11 lines
+  const lines = [];
+  for (let i = 0; i < n; i++) {
+    // Small alphabet so common subsequences actually occur.
+    lines.push("LMNOPQRST"[Math.floor(rand() * 9)]);
+  }
+  if (n === 0) return "";
+  const joined = lines.join("\n");
+  return rand() < 0.8 ? joined + "\n" : joined; // sometimes omit trailing newline
+}
+
+test("fuzz: applying our diff reconstructs new (correctness)", () => {
+  const rand = rng(0x1234abcd);
+  for (let iter = 0; iter < 5000; iter++) {
+    const oldStr = randomFile(rand);
+    const newStr = randomFile(rand);
+    const patch = createUnifiedDiff("a/f", "b/f", oldStr, newStr, 3);
+    const applied = applyUnified(oldStr, patch);
+    assert.equal(
+      applied,
+      newStr,
+      `iter ${iter}\n--old--\n${JSON.stringify(oldStr)}\n--new--\n${JSON.stringify(
+        newStr,
+      )}\n--patch--\n${patch}`,
+    );
+  }
+});
+
+test("fuzz: edit distance matches the diff package (minimality)", () => {
+  const rand = rng(0x55aa33cc);
+  for (let iter = 0; iter < 5000; iter++) {
+    const oldStr = randomFile(rand);
+    const newStr = randomFile(rand);
+    if (oldStr === newStr) continue;
+    const ours = createUnifiedDiff("a/f", "b/f", oldStr, newStr, 3);
+    const theirs = createTwoFilesPatch("a/f", "b/f", oldStr, newStr, undefined, undefined, {
+      context: 3,
+    });
+    assert.equal(
+      editCount(ours),
+      editCount(theirs),
+      `iter ${iter}\n--old--\n${JSON.stringify(oldStr)}\n--new--\n${JSON.stringify(
+        newStr,
+      )}\n--ours--\n${ours}\n--theirs--\n${theirs}`,
+    );
+  }
+});
+
+test("identical input yields empty diff", () => {
+  assert.equal(createUnifiedDiff("a/f", "b/f", "x\ny\n", "x\ny\n", 3), "");
+  assert.equal(createUnifiedDiff("a/f", "b/f", "", "", 3), "");
+});
+
+test("golden: single line replacement", () => {
+  const got = createUnifiedDiff("a/file.md", "b/file.md", "alpha\nbeta\n", "alpha\ngamma\n", 3);
+  assert.equal(
+    got,
+    ["--- a/file.md", "+++ b/file.md", "@@ -1,2 +1,2 @@", " alpha", "-beta", "+gamma", ""].join(
+      "\n",
+    ),
+  );
+});
+
+test("golden: pure insertion into empty file", () => {
+  const got = createUnifiedDiff("a/f", "b/f", "", "one\ntwo\n", 3);
+  assert.equal(got, ["--- a/f", "+++ b/f", "@@ -0,0 +1,2 @@", "+one", "+two", ""].join("\n"));
+});
+
+test("golden: pure deletion to empty file", () => {
+  const got = createUnifiedDiff("a/f", "b/f", "one\ntwo\n", "", 3);
+  assert.equal(got, ["--- a/f", "+++ b/f", "@@ -1,2 +0,0 @@", "-one", "-two", ""].join("\n"));
+});
+
+test("no trailing newline is marked", () => {
+  const got = createUnifiedDiff("a/f", "b/f", "alpha\nbeta", "alpha\ngamma", 3);
+  assert.ok(got.includes("-beta"));
+  assert.ok(got.includes("+gamma"));
+  assert.ok(got.includes("\\ No newline at end of file"));
+  // Round-trips.
+  assert.equal(applyUnified("alpha\nbeta", got), "alpha\ngamma");
+});
+
+test("trailing-newline-only change round-trips", () => {
+  const a = "alpha\nbeta\n";
+  const b = "alpha\nbeta";
+  const got = createUnifiedDiff("a/f", "b/f", a, b, 3);
+  assert.notEqual(got, "");
+  assert.equal(applyUnified(a, got), b);
+});
+
+test("separated changes split into multiple hunks", () => {
+  const oldStr = Array.from({ length: 20 }, (_, i) => `line${i}`).join("\n") + "\n";
+  const lines = oldStr.slice(0, -1).split("\n");
+  lines[0] = "CHANGED0";
+  lines[19] = "CHANGED19";
+  const newStr = lines.join("\n") + "\n";
+  const got = createUnifiedDiff("a/f", "b/f", oldStr, newStr, 3);
+  const hunks = got.split("\n").filter((l) => l.startsWith("@@")).length;
+  assert.equal(hunks, 2, got);
+  assert.equal(applyUnified(oldStr, got), newStr);
+});


### PR DESCRIPTION
## What

Removes the `diff` package from `rosie-skills`' runtime dependencies, replacing its single use (`createTwoFilesPatch` in `audit.ts`) with a small local generator, `src/unified-diff.ts`.

## Why

`diff` was ~670K on disk and powered exactly one call: the unified diff stored in the audit record on updates. That diff is human/agent review text, never machine-applied, and no test snapshots its exact bytes, so a local implementation is safe.

**Consumer-install dependency footprint drops from ~772K to ~104K** (only `modern-tar` remains).

## How it's verified

`test/diff.test.mjs` fuzzes 5000 random input pairs two ways:

- **Correctness** — an independent applier reconstructs the new text from `old` + our diff, exactly.
- **Minimality** — our edit distance (adds + deletes) equals the `diff` package's for the same inputs. Equal counts mean our output is as tight as jsdiff's.

Plus golden exact-string tests and edge cases (empty files, single line, missing trailing newline with the `\ No newline` marker, newline-only change, multi-hunk splitting). `diff` is kept as a **devDependency** purely to power the differential minimality check.

A `Run pure-JS unit tests` step runs them in the `build-js` CI job.

## Notes

- `src/unified-diff.ts`: LCS-based, git-style unified diff. Common prefix/suffix trimming keeps the O(n·m) table on just the changed region; a cell-count guard falls back to wholesale replace for pathological large rewrites.
- The `unifiedDiff(name, old, new)` signature in `audit.ts` is unchanged, so the three `install.ts` call sites are untouched.
- Output uses bare `\n` (matching the Rust `similar` side and the wasm-parity contract), consistent with the rest of the package.