### PR TITLE
perf: shrink package size by ~48% unpacked

### DIFF
--- a/npm/rosie-skills/README.md
+++ b/npm/rosie-skills/README.md
@@ -184,8 +184,8 @@ await rosie.installFromLockfile();
 
 This package is pure JavaScript. The CLI and the JS API run the same
 TypeScript implementation in-process — no native binary, no WebAssembly. It
-works anywhere Node 18+ runs. The only runtime dependencies are `tar` (tarball
-extraction) and `diff` (audit-log diffs).
+works anywhere Node 18+ runs. The only runtime dependency is `modern-tar`
+(tarball extraction).
 
 ## Standalone binary
 

--- a/npm/rosie-skills/tsconfig.json
+++ b/npm/rosie-skills/tsconfig.json
@@ -7,8 +7,6 @@
     "rootDir": "src",
     "outDir": "dist",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
This drops `sourceMap` and `declarationMap` from `tsconfig.json` so the published package no longer ships source maps, and fixed a stale line in the README (the only runtime dep is `modern-tar`, not `tar` + `diff`).

| | Before | After |
|---|---|---|
| Download (gzip) | 73.6 kB | **45.7 kB** (−38%) |
| Unpacked | 349.5 kB | **180.8 kB** (−48%) |
| Files | 86 | 44 |

The published sourcemaps did nothing as only `dist` was published, not `src`, so the maps pointed at `src/*.ts` paths that aren't in the package and could never resolve. They were ~49% of the tarball.