### PR TITLE
perf: extract tarballs in a single decompression pass

### DIFF
--- a/npm/rosie-skills/package.json
+++ b/npm/rosie-skills/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "node --test test/diff.test.mjs"
+    "test": "node --test test/*.test.mjs"
   },
   "repository": {
     "type": "git",

--- a/npm/rosie-skills/src/archive.ts
+++ b/npm/rosie-skills/src/archive.ts
@@ -1,72 +1,61 @@
 // Tar.gz extraction via modern-tar. Ported from src/archive.rs.
 //
-// Two entry points:
-//   - extractTarball(archivePath, destDir): extract everything under destDir.
-//   - rootDir(archivePath): the first path component of the first archive
-//     entry, which is GitHub's <repo>-<ref> wrapper dir.
-//
-// modern-tar handles gzip (via the gunzip step below), PAX/GNU long names,
-// symlinks, mode bits, and path-traversal protection (it rejects ".."
-// components and validates symlink/hardlink targets stay inside destDir), so
-// this is thin wiring over it. Both functions are async: modern-tar is
-// stream-based and has no synchronous API.
+// extractTarball extracts everything under destDir and returns the archive's
+// root dir (GitHub's <repo>-<ref> wrapper). modern-tar handles gzip, PAX/GNU
+// long names, symlinks, mode bits, and path-traversal protection, so this is
+// thin wiring over it.
 
 import * as fs from "node:fs";
 import * as zlib from "node:zlib";
-import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { unpackTar } from "modern-tar/fs";
-import { createTarDecoder } from "modern-tar";
 import * as os from "./os.js";
 import * as log from "./log.js";
+
+export interface ExtractResult {
+  rc: number; // 0 on success, -1 on failure
+  root: string | null; // <repo>-<ref> wrapper dir, or null if failed/empty
+}
 
 function errMsg(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
-// Extract the tar.gz at archivePath into destDir. Returns 0 on success, -1 on
-// failure. Mirrors archive.rs::extract_tarball.
-export async function extractTarball(archivePath: string, destDir: string): Promise<number> {
+// Extract the tar.gz at archivePath into destDir, capturing the root dir in
+// the same pass via modern-tar's `filter` (called for every entry in archive
+// order). Mirrors archive.rs::extract_tarball + root_dir, but reads the
+// archive once instead of decompressing again just to peek at the first entry.
+export async function extractTarball(archivePath: string, destDir: string): Promise<ExtractResult> {
   try {
     os.createDirAll(destDir);
   } catch (e) {
     log.error(`Cannot create dest dir: ${errMsg(e)}`);
-    return -1;
+    return { rc: -1, root: null };
   }
   log.debug(`Extracting to: ${destDir}`);
+
+  let root: string | null = null;
   try {
-    // GitHub tarballs are gzipped; gunzip before handing raw tar to unpackTar.
-    // No `strip` — the <repo>-<ref> wrapper dir is kept and found by rootDir.
+    // Gunzip before handing raw tar to unpackTar. No `strip` — the wrapper
+    // dir is kept; `filter` records it.
     await pipeline(
       fs.createReadStream(archivePath),
       zlib.createGunzip(),
-      unpackTar(destDir),
+      unpackTar(destDir, {
+        // Not filtering — observing. The decoder calls this once per entry in
+        // archive order, so the first one is the <repo>-<ref> wrapper.
+        filter: (header) => {
+          if (root === null) {
+            const first = header.name.split("/")[0];
+            if (first && first.length > 0) root = first;
+          }
+          return true; // keep every entry
+        },
+      }),
     );
   } catch (e) {
     log.error(`Error reading archive: ${errMsg(e)}`);
-    return -1;
+    return { rc: -1, root: null };
   }
-  return 0;
-}
-
-// Find the first path component of the first real entry in the archive.
-// GitHub tarballs wrap the repo in <repo>-<ref>/. modern-tar applies PAX
-// extended headers internally rather than emitting pseudo-entries, so the
-// first decoded entry is already a real one. Mirrors archive.rs::root_dir.
-export async function rootDir(archivePath: string): Promise<string | null> {
-  try {
-    const bytes = Readable.toWeb(
-      fs.createReadStream(archivePath).pipe(zlib.createGunzip()),
-    );
-    const entries = bytes.pipeThrough(createTarDecoder());
-    for await (const entry of entries) {
-      const first = entry.header.name.split("/")[0];
-      // Drain the body before moving on / returning, or the stream stalls.
-      await entry.body.cancel();
-      if (first && first.length > 0) return first;
-    }
-  } catch {
-    return null;
-  }
-  return null;
+  return { rc: 0, root };
 }

--- a/npm/rosie-skills/src/install.ts
+++ b/npm/rosie-skills/src/install.ts
@@ -749,13 +749,14 @@ export async function installPackage(opts: InstallOptions): Promise<number> {
   }
 
   log.info("Extracting...");
-  if ((await archive.extractTarball(tarballPath, tempDir)) !== 0) {
+  const extracted = await archive.extractTarball(tarballPath, tempDir);
+  if (extracted.rc !== 0) {
     log.error("Failed to extract package");
     safeRemoveDir(tempDir);
     return -1;
   }
 
-  const root = await archive.rootDir(tarballPath);
+  const root = extracted.root;
   const extractedPath = root !== null ? path.join(tempDir, root) : tempDir;
 
   if (opts.isReference) {

--- a/npm/rosie-skills/test/archive.test.mjs
+++ b/npm/rosie-skills/test/archive.test.mjs
@@ -1,0 +1,85 @@
+// Tests for src/archive.ts (compiled to dist/archive.js). Fixtures are real
+// .tar.gz bytes built with modern-tar's packTar + gzip, so this runs against
+// the actual extractor, not a mock.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as zlib from "node:zlib";
+import { packTar } from "modern-tar/fs";
+
+import { extractTarball } from "../dist/archive.js";
+
+// Build a gzipped tar from [{target, content}] entries (order preserved, so
+// entries[0] determines the root) and write it to a temp file.
+async function writeTarGz(entries) {
+  const sources = entries.map((e) => ({
+    type: "content",
+    content: e.content,
+    target: e.target,
+  }));
+  const chunks = [];
+  for await (const chunk of packTar(sources)) chunks.push(chunk);
+  const gz = zlib.gzipSync(Buffer.concat(chunks));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rosie-arc-src-"));
+  const tarPath = path.join(dir, "package.tar.gz");
+  fs.writeFileSync(tarPath, gz);
+  return tarPath;
+}
+
+function freshDest() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "rosie-arc-dest-"));
+}
+
+test("extracts files and reports the root wrapper dir", async () => {
+  const tar = await writeTarGz([
+    { target: "myrepo-main/SKILL.md", content: "# hello\n" },
+    { target: "myrepo-main/scripts/run.sh", content: "echo hi\n" },
+  ]);
+  const dest = freshDest();
+
+  const result = await extractTarball(tar, dest);
+
+  assert.equal(result.rc, 0);
+  assert.equal(result.root, "myrepo-main");
+  assert.equal(fs.readFileSync(path.join(dest, "myrepo-main/SKILL.md"), "utf8"), "# hello\n");
+  assert.equal(
+    fs.readFileSync(path.join(dest, "myrepo-main/scripts/run.sh"), "utf8"),
+    "echo hi\n",
+  );
+});
+
+test("root is the first component of the first entry", async () => {
+  const tar = await writeTarGz([
+    { target: "repo-v1.2.3/README.md", content: "x\n" },
+    { target: "repo-v1.2.3/a/b/c.txt", content: "y\n" },
+  ]);
+  const dest = freshDest();
+
+  const result = await extractTarball(tar, dest);
+
+  assert.equal(result.rc, 0);
+  assert.equal(result.root, "repo-v1.2.3");
+  assert.equal(fs.readFileSync(path.join(dest, "repo-v1.2.3/a/b/c.txt"), "utf8"), "y\n");
+});
+
+test("missing archive fails cleanly (rc -1, no root)", async () => {
+  const dest = freshDest();
+  const result = await extractTarball(path.join(dest, "does-not-exist.tar.gz"), dest);
+  assert.equal(result.rc, -1);
+  assert.equal(result.root, null);
+});
+
+test("non-gzip garbage fails cleanly (rc -1, no root)", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rosie-arc-bad-"));
+  const tarPath = path.join(dir, "package.tar.gz");
+  fs.writeFileSync(tarPath, Buffer.from("this is not a gzip stream"));
+  const dest = freshDest();
+
+  const result = await extractTarball(tarPath, dest);
+
+  assert.equal(result.rc, -1);
+  assert.equal(result.root, null);
+});


### PR DESCRIPTION
Previously, installing a remote skill decompressed the downloaded tarball **twice**: once to extract it (`extractTarball`), then again immediately after (`rootDir`) just to read the first entry's directory name — GitHub's `<repo>-<ref>` wrapper.
That second full gunzip + tar-decode pass was unnecessary since it's already streamed every byte one line earlier.

This merges `rootDir` into `extractTarball`. The root dir is now captured *during* the extraction pass via modern-tar's `filter` callback, which the decoder invokes once per entry in archive order. So the first entry it sees is the wrapper, the same answer the old separate pass returned. `extractTarball` now returns `{ rc, root }` instead of a bare status code.

**Before**
- 2 full gunzip + tar-decode passes per remote install/update

**After**
- 1 pass — the second decompression is gone entirely

`test/archive.test.mjs` was added to verify behaviour - happy to tweak this as requested.