### PR TITLE
Serve apt/FreeBSD package repos from R2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -136,6 +136,22 @@ jobs:
           git pull --rebase origin gh-pages
           git push
 
+      # The gh-pages branch above is the canonical accumulating store; R2 is the
+      # served copy behind pkg.rosie.astro.build. We sync only freebsd/ so this
+      # job never races the debian job's prefix (sync deletes within its target).
+      - name: Set up rclone
+        uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1.12.0
+
+      - name: Publish FreeBSD repo to R2
+        env:
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_REGION: auto
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+        run: rclone sync ./pages/freebsd/ r2:pkg-rosie/freebsd/ --checksum --s3-no-check-bucket
+
   debian-build:
     needs: create-release
     strategy:
@@ -233,6 +249,22 @@ jobs:
           # Rebase to pick up any concurrent push from freebsd job (different subdir, no conflict)
           git pull --rebase origin gh-pages
           git push
+
+      # The gh-pages branch above is the canonical accumulating store; R2 is the
+      # served copy behind pkg.rosie.astro.build. We sync only debian/ so this
+      # job never races the freebsd job's prefix (sync deletes within its target).
+      - name: Set up rclone
+        uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1.12.0
+
+      - name: Publish Debian repo to R2
+        env:
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_REGION: auto
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+        run: rclone sync ./pages/debian/ r2:pkg-rosie/debian/ --checksum --s3-no-check-bucket
 
   npm-publish:
     needs: [create-release]

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -113,7 +113,7 @@ title: rosie
 
   <div class="tab-panel" data-panel="apt">
     <p class="panel-note"><span class="comment"># noble for ubuntu 24.04 / debian 13+, jammy for ubuntu 22.04</span></p>
-<pre class="term-block"><span class="prompt">$</span> echo "deb [trusted=yes] https://withastro.github.io/rosie/debian noble main" \
+<pre class="term-block"><span class="prompt">$</span> echo "deb [trusted=yes] https://pkg.rosie.astro.build/debian noble main" \
     | sudo tee /etc/apt/sources.list.d/rosie.list
 <span class="prompt">$</span> sudo apt update
 <span class="prompt">$</span> sudo apt install rosie<button class="copy-btn" data-copy>[ copy ]</button></pre>
@@ -124,7 +124,7 @@ title: rosie
 <pre class="term-block"><span class="prompt">$</span> sudo mkdir -p /usr/local/etc/pkg/repos
 <span class="prompt">$</span> cat &lt;&lt;'EOF' | sudo tee /usr/local/etc/pkg/repos/rosie.conf
 rosie: {
-  url: "https://withastro.github.io/rosie/freebsd/",
+  url: "https://pkg.rosie.astro.build/freebsd/",
   enabled: yes,
   signature_type: "none"
 }


### PR DESCRIPTION
## Why

GitHub Pages was never enabled after the repo moved to the `withastro` org, so the apt and FreeBSD repo URLs 404 and those installs are currently broken. npm/Homebrew/AUR are unaffected.

## What

Serve both package repos from a Cloudflare R2 bucket behind a custom domain.

- `gh-pages` stays the canonical accumulating store; the release jobs commit/push it as before, then mirror their own prefix to R2 with `rclone sync`.
- Each job syncs only its subtree to a disjoint R2 prefix, so they never race.
- rclone over R2's S3 API (`wrangler r2 object put` is single-object only).
- Install docs repointed to the new domain.

Some one-time account setup is required before this works; that's tracked separately, not here.