### PR TITLE
Add missing agents to the registry

### DIFF
--- a/design/js-rewrite.md
+++ b/design/js-rewrite.md
@@ -88,7 +88,7 @@ divergence, so `src/os/` collapses into direct `node:fs` / `node:os` /
 | `src/util.rs` | `util.ts` | path join (`node:path`), home/temp dir, fs helpers, the hand-rolled `package.json` version scanner. |
 | `src/lockfile.rs` | `lockfile.ts` | Custom whitespace format, `# rosie-lock v1` header, atomic write (`.tmp` then rename). ISO-8601 via `Date`. |
 | `src/skill.rs` | `skill.ts` | YAML frontmatter mini-parser (`name`, `description`), `discover_skills` with the same search paths + depth-5 limit. |
-| `src/agent.rs` | `agent.ts` | Port `AGENT_DEFS` (58 entries) verbatim. `detect_agents`, install-path resolution. |
+| `src/agent.rs` | `agent.ts` | Port `AGENT_DEFS` (73 entries) verbatim. `detect_agents`, install-path resolution. |
 | `src/agentsmd.rs` | `agentsmd.ts` | The `<!-- rosie:references:start -->` block rewriter across AGENTS.md / CLAUDE.md / GEMINI.md / copilot-instructions. |
 | `src/sanitize.rs` | `sanitize.ts` | Invisible-char stripping + markdown-comment stripping outside fences. Pure text, direct port. |
 | `src/archive.rs` | `archive.ts` | `gunzipSync` + hand-rolled tar reader. `get_archive_root_dir` reads the first entry. |

--- a/npm/rosie-skills/src/agent.ts
+++ b/npm/rosie-skills/src/agent.ts
@@ -80,8 +80,26 @@ export const AGENT_DEFS: AgentDef[] = [
   { name: "rovodev", display: "Rovo Dev", aliases: [], projectPath: ".rovodev/skills", globalPath: ".rovodev/skills", detectDir: ".rovodev", binary: null },
   { name: "trae", display: "Trae", aliases: [], projectPath: ".trae/skills", globalPath: ".trae/skills", detectDir: ".trae", binary: null },
   { name: "trae-cn", display: "Trae CN", aliases: [], projectPath: ".trae/skills", globalPath: ".trae-cn/skills", detectDir: ".trae-cn", binary: null },
-  { name: "zencoder", display: "Zencoder", aliases: [], projectPath: ".zencoder/skills", globalPath: ".zencoder/skills", detectDir: ".zencoder", binary: null },
+  { name: "zencoder", display: "Zencoder", aliases: ["zenflow"], projectPath: ".zencoder/skills", globalPath: ".zencoder/skills", detectDir: ".zencoder", binary: null },
   { name: "adal", display: "AdaL", aliases: [], projectPath: ".adal/skills", globalPath: ".adal/skills", detectDir: ".adal", binary: null },
+
+  // --- Tier 4 additions ---
+  { name: "antigravity-cli", display: "Antigravity CLI", aliases: [], projectPath: ".agents/skills", globalPath: ".gemini/antigravity-cli/skills", detectDir: ".gemini/antigravity-cli", binary: null },
+  { name: "astrbot", display: "AstrBot", aliases: [], projectPath: "data/skills", globalPath: ".astrbot/data/skills", detectDir: ".astrbot", binary: null },
+  { name: "autohand-code", display: "Autohand Code CLI", aliases: [], projectPath: ".autohand/skills", globalPath: ".autohand/skills", detectDir: ".autohand", binary: null },
+  { name: "eve", display: "Eve", aliases: [], projectPath: "agent/skills", globalPath: "agent/skills", detectDir: "", binary: null },
+  { name: "inference-sh", display: "inference.sh", aliases: [], projectPath: ".inferencesh/skills", globalPath: ".inferencesh/skills", detectDir: ".inferencesh", binary: null },
+  { name: "jazz", display: "Jazz", aliases: [], projectPath: ".jazz/skills", globalPath: ".jazz/skills", detectDir: ".jazz", binary: null },
+  { name: "lingma", display: "Lingma", aliases: [], projectPath: ".lingma/skills", globalPath: ".lingma/skills", detectDir: ".lingma", binary: null },
+  { name: "loaf", display: "Loaf", aliases: [], projectPath: ".agents/skills", globalPath: ".agents/skills", detectDir: ".loaf", binary: null },
+  { name: "moxby", display: "Moxby", aliases: [], projectPath: ".moxby/skills", globalPath: ".moxby/skills", detectDir: ".moxby", binary: null },
+  { name: "ona", display: "Ona", aliases: [], projectPath: ".ona/skills", globalPath: ".ona/skills", detectDir: ".ona", binary: null },
+  { name: "promptscript", display: "PromptScript", aliases: [], projectPath: ".agents/skills", globalPath: ".agents/skills", detectDir: "", binary: null },
+  { name: "qoder-cn", display: "Qoder CN", aliases: [], projectPath: ".qoder/skills", globalPath: ".qoder-cn/skills", detectDir: ".qoder-cn", binary: null },
+  { name: "reasonix", display: "Reasonix", aliases: [], projectPath: ".reasonix/skills", globalPath: ".reasonix/skills", detectDir: ".reasonix", binary: null },
+  { name: "terramind", display: "Terramind", aliases: [], projectPath: ".terramind/skills", globalPath: ".terramind/skills", detectDir: ".terramind", binary: null },
+  { name: "tinycloud", display: "Tinycloud", aliases: [], projectPath: ".tinycloud/skills", globalPath: ".tinycloud/skills", detectDir: ".tinycloud", binary: null },
+
   { name: "universal", display: "Universal", aliases: [], projectPath: ".agents/skills", globalPath: ".config/agents/skills", detectDir: "", binary: null },
 ];
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -84,8 +84,26 @@ pub const AGENT_DEFS: &[AgentDef] = &[
     AgentDef { name: "rovodev",        display: "Rovo Dev",        aliases: &[],   project_path: ".rovodev/skills",        global_path: ".rovodev/skills",               detect_dir: ".rovodev",            binary: None },
     AgentDef { name: "trae",           display: "Trae",            aliases: &[],   project_path: ".trae/skills",           global_path: ".trae/skills",                  detect_dir: ".trae",               binary: None },
     AgentDef { name: "trae-cn",        display: "Trae CN",         aliases: &[],   project_path: ".trae/skills",           global_path: ".trae-cn/skills",               detect_dir: ".trae-cn",            binary: None },
-    AgentDef { name: "zencoder",       display: "Zencoder",        aliases: &[],   project_path: ".zencoder/skills",       global_path: ".zencoder/skills",              detect_dir: ".zencoder",           binary: None },
+    AgentDef { name: "zencoder",       display: "Zencoder",        aliases: &["zenflow"], project_path: ".zencoder/skills",  global_path: ".zencoder/skills",              detect_dir: ".zencoder",           binary: None },
     AgentDef { name: "adal",           display: "AdaL",            aliases: &[],   project_path: ".adal/skills",           global_path: ".adal/skills",                  detect_dir: ".adal",               binary: None },
+
+    // --- Tier 4 additions ---
+    AgentDef { name: "antigravity-cli", display: "Antigravity CLI", aliases: &[],  project_path: ".agents/skills",        global_path: ".gemini/antigravity-cli/skills", detect_dir: ".gemini/antigravity-cli", binary: None },
+    AgentDef { name: "astrbot",        display: "AstrBot",         aliases: &[],   project_path: "data/skills",            global_path: ".astrbot/data/skills",          detect_dir: ".astrbot",            binary: None },
+    AgentDef { name: "autohand-code",  display: "Autohand Code CLI", aliases: &[], project_path: ".autohand/skills",       global_path: ".autohand/skills",              detect_dir: ".autohand",           binary: None },
+    AgentDef { name: "eve",            display: "Eve",             aliases: &[],   project_path: "agent/skills",           global_path: "agent/skills",                  detect_dir: "",                    binary: None },
+    AgentDef { name: "inference-sh",   display: "inference.sh",    aliases: &[],   project_path: ".inferencesh/skills",    global_path: ".inferencesh/skills",           detect_dir: ".inferencesh",        binary: None },
+    AgentDef { name: "jazz",           display: "Jazz",            aliases: &[],   project_path: ".jazz/skills",           global_path: ".jazz/skills",                  detect_dir: ".jazz",               binary: None },
+    AgentDef { name: "lingma",         display: "Lingma",          aliases: &[],   project_path: ".lingma/skills",         global_path: ".lingma/skills",                detect_dir: ".lingma",             binary: None },
+    AgentDef { name: "loaf",           display: "Loaf",            aliases: &[],   project_path: ".agents/skills",         global_path: ".agents/skills",                detect_dir: ".loaf",               binary: None },
+    AgentDef { name: "moxby",          display: "Moxby",           aliases: &[],   project_path: ".moxby/skills",          global_path: ".moxby/skills",                 detect_dir: ".moxby",              binary: None },
+    AgentDef { name: "ona",            display: "Ona",             aliases: &[],   project_path: ".ona/skills",            global_path: ".ona/skills",                   detect_dir: ".ona",                binary: None },
+    AgentDef { name: "promptscript",   display: "PromptScript",    aliases: &[],   project_path: ".agents/skills",         global_path: ".agents/skills",                detect_dir: "",                    binary: None },
+    AgentDef { name: "qoder-cn",       display: "Qoder CN",        aliases: &[],   project_path: ".qoder/skills",          global_path: ".qoder-cn/skills",              detect_dir: ".qoder-cn",           binary: None },
+    AgentDef { name: "reasonix",       display: "Reasonix",        aliases: &[],   project_path: ".reasonix/skills",       global_path: ".reasonix/skills",              detect_dir: ".reasonix",           binary: None },
+    AgentDef { name: "terramind",      display: "Terramind",       aliases: &[],   project_path: ".terramind/skills",      global_path: ".terramind/skills",             detect_dir: ".terramind",          binary: None },
+    AgentDef { name: "tinycloud",      display: "Tinycloud",       aliases: &[],   project_path: ".tinycloud/skills",      global_path: ".tinycloud/skills",             detect_dir: ".tinycloud",          binary: None },
+
     AgentDef { name: "universal",      display: "Universal",       aliases: &[],   project_path: ".agents/skills",         global_path: ".config/agents/skills",         detect_dir: "",                    binary: None },
 ];
 
@@ -188,7 +206,7 @@ mod tests {
 
     #[test]
     fn known_count() {
-        assert_eq!(AGENT_DEFS.len(), 58);
+        assert_eq!(AGENT_DEFS.len(), 73);
     }
 
     #[test]

--- a/tests/wasm-parity/run.mjs
+++ b/tests/wasm-parity/run.mjs
@@ -62,7 +62,7 @@ async function withTmp(name, fn) {
 await withTmp('agents', async () => {
     const agents = await rosie.agents();
     // Matches the supported-agent count pinned by the Rust agent.rs test.
-    assert(agents.length === 58, `expected 58 agent defs, got ${agents.length}`);
+    assert(agents.length === 73, `expected 73 agent defs, got ${agents.length}`);
     const claude = agents.find(a => a.name === 'claude');
     assert(claude !== undefined, 'claude entry missing');
     assert(claude.detected === true, 'claude should be detected');

--- a/website/src/content/docs/agents.md
+++ b/website/src/content/docs/agents.md
@@ -14,14 +14,17 @@ navOrder: 5
 <section class="supported">
   <p class="lockfile-intro">agents are auto-detected by the presence of their config directory in <code>$HOME</code>. target them explicitly with <code>--agent &lt;name&gt;</code>.</p>
 
-  <h3 class="sub-label">skills · 58 supported</h3>
+  <h3 class="sub-label">skills · 73 supported</h3>
   <ul class="bullet-list">
     <li><span class="bullet">▸</span><strong class="key">adal</strong><span class="val">AdaL · <code>~/.adal/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">aider</strong><span class="val">AiderDesk · <code>~/.aider-desk/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">aider-desk</strong><span class="val">AiderDesk · <code>~/.aider-desk/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">amp</strong><span class="val">Amp · <code>~/.config/agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">antigravity</strong><span class="val">Antigravity · <code>~/.gemini/antigravity/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">antigravity-cli</strong><span class="val">Antigravity CLI · <code>~/.gemini/antigravity-cli/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">astrbot</strong><span class="val">AstrBot · <code>~/.astrbot/data/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">augment</strong><span class="val">Augment Code · <code>~/.augment/skills/</code> · alias: <code>amplify</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">autohand-code</strong><span class="val">Autohand Code CLI · <code>~/.autohand/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">bob</strong><span class="val">IBM Bob · <code>~/.bob/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">claude</strong><span class="val">Claude Code · <code>~/.claude/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">cline</strong><span class="val">Cline · <code>~/.cline/skills/</code></span></li>
@@ -40,40 +43,52 @@ navOrder: 5
     <li><span class="bullet">▸</span><strong class="key">devin</strong><span class="val">Devin · <code>~/.config/devin/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">dexto</strong><span class="val">Dexto · <code>~/.agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">droid</strong><span class="val">Droid (Factory) · <code>~/.factory/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">eve</strong><span class="val">Eve · <code>agent/skills/</code> · explicit only (no auto-detect)</span></li>
     <li><span class="bullet">▸</span><strong class="key">firebender</strong><span class="val">Firebender · <code>~/.firebender/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">forgecode</strong><span class="val">ForgeCode · <code>~/.forge/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">gemini-cli</strong><span class="val">Gemini CLI · <code>~/.gemini/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">goose</strong><span class="val">Goose · <code>~/.config/goose/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">hermes-agent</strong><span class="val">Hermes Agent · <code>~/.hermes/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">iflow-cli</strong><span class="val">iFlow CLI · <code>~/.iflow/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">inference-sh</strong><span class="val">inference.sh · <code>~/.inferencesh/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">jazz</strong><span class="val">Jazz · <code>~/.jazz/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">junie</strong><span class="val">Junie · <code>~/.junie/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">kilo</strong><span class="val">Kilo Code · <code>~/.kilocode/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">kimi-cli</strong><span class="val">Kimi Code CLI · <code>~/.config/agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">kiro-cli</strong><span class="val">Kiro CLI · <code>~/.kiro/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">kode</strong><span class="val">Kode · <code>~/.kode/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">lingma</strong><span class="val">Lingma · <code>~/.lingma/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">loaf</strong><span class="val">Loaf · <code>~/.agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">mcpjam</strong><span class="val">MCPJam · <code>~/.mcpjam/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">mistral-vibe</strong><span class="val">Mistral Vibe · <code>~/.vibe/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">moxby</strong><span class="val">Moxby · <code>~/.moxby/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">mux</strong><span class="val">Mux · <code>~/.mux/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">neovate</strong><span class="val">Neovate · <code>~/.neovate/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">ona</strong><span class="val">Ona · <code>~/.ona/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">opencode</strong><span class="val">OpenCode · <code>~/.config/opencode/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">openclaw</strong><span class="val">OpenClaw · <code>~/.openclaw/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">openhands</strong><span class="val">OpenHands · <code>~/.openhands/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">omp</strong><span class="val">OMP Agent · <code>~/.omp/agent/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">pi</strong><span class="val">Pi · <code>~/.pi/agent/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">pochi</strong><span class="val">Pochi · <code>~/.pochi/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">promptscript</strong><span class="val">PromptScript · <code>~/.agents/skills/</code> · explicit only (no auto-detect)</span></li>
     <li><span class="bullet">▸</span><strong class="key">qoder</strong><span class="val">Qoder · <code>~/.qoder/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">qoder-cn</strong><span class="val">Qoder CN · <code>~/.qoder-cn/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">qwen-code</strong><span class="val">Qwen Code · <code>~/.qwen/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">reasonix</strong><span class="val">Reasonix · <code>~/.reasonix/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">replit</strong><span class="val">Replit · <code>~/.config/agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">roo</strong><span class="val">Roo · <code>~/.roo/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">rovodev</strong><span class="val">Rovo Dev · <code>~/.rovodev/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">tabnine-cli</strong><span class="val">Tabnine CLI · <code>~/.tabnine/agent/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">terramind</strong><span class="val">Terramind · <code>~/.terramind/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">tinycloud</strong><span class="val">Tinycloud · <code>~/.tinycloud/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">trae</strong><span class="val">Trae · <code>~/.trae/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">trae-cn</strong><span class="val">Trae CN · <code>~/.trae-cn/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">universal</strong><span class="val">Universal · <code>~/.config/agents/skills/</code> · explicit only (no auto-detect)</span></li>
     <li><span class="bullet">▸</span><strong class="key">warp</strong><span class="val">Warp · <code>~/.agents/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">windsurf</strong><span class="val">Windsurf · <code>~/.codeium/windsurf/skills/</code></span></li>
     <li><span class="bullet">▸</span><strong class="key">zed</strong><span class="val">Zed · <code>~/.zed/skills/</code></span></li>
-    <li><span class="bullet">▸</span><strong class="key">zencoder</strong><span class="val">Zencoder · <code>~/.zencoder/skills/</code></span></li>
+    <li><span class="bullet">▸</span><strong class="key">zencoder</strong><span class="val">Zencoder · <code>~/.zencoder/skills/</code> · alias: <code>zenflow</code></span></li>
   </ul>
 
   <h3 class="sub-label">references</h3>


### PR DESCRIPTION
We were missing a number of supported agents. This adds them, taking `AGENT_DEFS` from 58 to 73.

**New agents (13):** astrbot, autohand-code, eve, inference-sh, jazz, lingma, loaf, moxby, ona, promptscript, reasonix, terramind, tinycloud

**Variants (2):** antigravity-cli, qoder-cn

**Alias:** zenflow → zencoder

`eve` and `promptscript` are project-only (explicit `-a`, no auto-detect).

Mirrored across all three sources: `src/agent.rs`, `npm/rosie-skills/src/agent.ts`, and the website agent list. Count test bumped to 73.

### Tests
- `cargo test --lib` — pass
- npm `typecheck` + `npm test` — pass