### PR TITLE
Move rosie to the rosieskills org and rosieskills.dev domains

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,11 +54,11 @@ jobs:
           SHA256: ${{ needs.create-release.outputs.sha256 }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         run: |
-          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/withastro/homebrew-rosie.git tap
+          git clone https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/rosieskills/homebrew-rosie.git tap
           cd tap
 
           # Org-agnostic match so this also rewrites a formula still pointing at the old org.
-          sed -i "s|url \"https://github.com/[^/]*/rosie/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/withastro/rosie/archive/refs/tags/v${VERSION}.tar.gz\"|" Formula/rosie.rb
+          sed -i "s|url \"https://github.com/[^/]*/rosie/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/rosieskills/rosie/archive/refs/tags/v${VERSION}.tar.gz\"|" Formula/rosie.rb
           sed -i "s|sha256 \".*\"|sha256 \"${SHA256}\"|" Formula/rosie.rb
 
           git config user.name "github-actions[bot]"
@@ -137,7 +137,7 @@ jobs:
           git push
 
       # The gh-pages branch above is the canonical accumulating store; R2 is the
-      # served copy behind pkg.rosie.astro.build. We sync only freebsd/ so this
+      # served copy behind pkg.rosieskills.dev. We sync only freebsd/ so this
       # job never races the debian job's prefix (sync deletes within its target).
       - name: Set up rclone
         uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1.12.0
@@ -251,7 +251,7 @@ jobs:
           git push
 
       # The gh-pages branch above is the canonical accumulating store; R2 is the
-      # served copy behind pkg.rosie.astro.build. We sync only debian/ so this
+      # served copy behind pkg.rosieskills.dev. We sync only debian/ so this
       # job never races the freebsd job's prefix (sync deletes within its target).
       - name: Set up rclone
         uses: AnimMouse/setup-rclone@26ef2133e09fd383329a1d4c1fbe6a71db1976c9 # v1.12.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.8.5"
 edition = "2021"
 license = "BSD-3-Clause"
 description = "A robot helper for agent skills"
-homepage = "https://github.com/withastro/rosie"
-repository = "https://github.com/withastro/rosie"
+homepage = "https://github.com/rosieskills/rosie"
+repository = "https://github.com/rosieskills/rosie"
 publish = false
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx rosie-skills install owner/repo
 Via Homebrew:
 
 ```bash
-brew tap withastro/rosie
+brew tap rosieskills/rosie
 brew install rosie
 ```
 
@@ -27,18 +27,18 @@ on the docs site.
 ## Documentation
 
 Full docs, including the CLI reference, the typed JavaScript API, lockfile
-format, supported agents, and more: **<https://rosie.astro.build/>**.
+format, supported agents, and more: **<https://rosieskills.dev/>**.
 
 A quick jump table:
 
-- **[install](https://rosie.astro.build/#install)** — all install methods
-- **[cli](https://rosie.astro.build/docs/cli/)** — commands and flags
-- **[lockfile](https://rosie.astro.build/docs/lockfile/)** — `.agents/rosie.lock` format
-- **[references](https://rosie.astro.build/docs/references/)** — markdown docs as agent context
-- **[js api](https://rosie.astro.build/docs/js-api/)** — `import * as rosie from 'rosie-skills'`
-- **[supported](https://rosie.astro.build/docs/agents/)** — detected agents
-- **[skill format](https://rosie.astro.build/docs/skill-format/)** — anatomy of a skill
-- **[how it works](https://rosie.astro.build/docs/how-it-works/)** — what happens on install
+- **[install](https://rosieskills.dev/#install)** — all install methods
+- **[cli](https://rosieskills.dev/docs/cli/)** — commands and flags
+- **[lockfile](https://rosieskills.dev/docs/lockfile/)** — `.agents/rosie.lock` format
+- **[references](https://rosieskills.dev/docs/references/)** — markdown docs as agent context
+- **[js api](https://rosieskills.dev/docs/js-api/)** — `import * as rosie from 'rosie-skills'`
+- **[supported](https://rosieskills.dev/docs/agents/)** — detected agents
+- **[skill format](https://rosieskills.dev/docs/skill-format/)** — anatomy of a skill
+- **[how it works](https://rosieskills.dev/docs/how-it-works/)** — what happens on install
 
 ## License
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -4,7 +4,7 @@ pkgver=${VERSION}
 pkgrel=1
 pkgdesc="A robot helper for agent skills"
 arch=('x86_64' 'aarch64')
-url="https://github.com/withastro/rosie"
+url="https://github.com/rosieskills/rosie"
 license=('BSD-3-Clause')
 # The Rust binary statically links rustls; no system curl/libarchive needed.
 makedepends=('rust' 'cargo')
@@ -13,7 +13,7 @@ makedepends=('rust' 'cargo')
 # doesn't run gcc's LTO front-end on them, so every ring_core_0_17_14__*
 # symbol comes back undefined. Opting out of LTO restores native ELF objects.
 options=('!lto')
-source=("$pkgname-$pkgver.tar.gz::https://github.com/withastro/rosie/archive/refs/tags/v$pkgver.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/rosieskills/rosie/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('${SHA256}')
 
 build() {

--- a/aur/publish-initial.sh
+++ b/aur/publish-initial.sh
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 PKGNAME="rosie"
-REPO="withastro/rosie"
+REPO="rosieskills/rosie"
 TEMPLATE="$(cd "$(dirname "$0")" && pwd)/PKGBUILD"
 
 # --- resolve version ---

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: utils
 Priority: optional
 Architecture: amd64
 Maintainer: Matthew Phillips <matthew@matthewphillips.info>
-Homepage: https://github.com/withastro/rosie
+Homepage: https://github.com/rosieskills/rosie
 Description: A robot helper for agent skills
  A fast, cross-platform package manager for AI agent skills.
  Think npm, but for skills.

--- a/freebsd-package/bootstrap-gh-pages.sh
+++ b/freebsd-package/bootstrap-gh-pages.sh
@@ -51,7 +51,7 @@ if [[ "$ans" =~ ^[Yy]$ ]]; then
     git push -u origin gh-pages
     echo
     echo "==> Done. Next: enable GitHub Pages at"
-    echo "    https://github.com/withastro/rosie/settings/pages"
+    echo "    https://github.com/rosieskills/rosie/settings/pages"
     echo "    Source: 'Deploy from a branch'"
     echo "    Branch: gh-pages, folder: / (root)"
 else

--- a/freebsd-package/pkg-manifest.ucl
+++ b/freebsd-package/pkg-manifest.ucl
@@ -3,7 +3,7 @@ version: "${VERSION}"
 origin: sysutils/rosie
 comment: A robot helper for agent skills
 maintainer: matthew@matthewphillips.info
-www: https://github.com/withastro/rosie
+www: https://github.com/rosieskills/rosie
 abi: FreeBSD:14:amd64
 arch: freebsd:14:x86:64
 prefix: /usr/local

--- a/local-skills/release/SKILL.md
+++ b/local-skills/release/SKILL.md
@@ -10,7 +10,7 @@ Rosie ships two artifacts from one tag:
 - the **standalone Rust `rosie` binary** (Homebrew, AUR, Debian/Ubuntu, FreeBSD), and
 - the **`rosie-skills` npm package** (pure TypeScript).
 
-Releases are **tag-driven**. Pushing a `v*` tag to `withastro/rosie` runs
+Releases are **tag-driven**. Pushing a `v*` tag to `rosieskills/rosie` runs
 `.github/workflows/release.yaml`, which builds and publishes everything. You do
 not publish anything by hand.
 
@@ -70,7 +70,7 @@ For a release `X.Y.Z` (example: `0.8.0`):
   tarball SHA256 used by Homebrew/AUR.
 - **npm-publish** - sets the version from the tag, builds `dist/` via `tsc`,
   runs `npm publish` for `rosie-skills` (npm OIDC, no token).
-- **homebrew-and-aur** - updates the `withastro/homebrew-rosie` formula and the
+- **homebrew-and-aur** - updates the `rosieskills/homebrew-rosie` formula and the
   AUR `PKGBUILD`.
 - **debian-build** + **debian-publish** - builds `.deb`s for jammy and noble,
   publishes the apt repo to `gh-pages`.
@@ -82,8 +82,8 @@ For a release `X.Y.Z` (example: `0.8.0`):
 
 ```sh
 # Release workflow + per-job status
-gh run list --repo withastro/rosie --workflow release.yaml --limit 1
-gh run view <run-id> --repo withastro/rosie
+gh run list --repo rosieskills/rosie --workflow release.yaml --limit 1
+gh run view <run-id> --repo rosieskills/rosie
 
 # npm published and tagged latest
 npm view rosie-skills version dist-tags

--- a/npm/rosie-skills/README.md
+++ b/npm/rosie-skills/README.md
@@ -134,7 +134,7 @@ await rosie.update('pdf');      // update just one
 ### Security defenses
 
 Every install applies content sanitization and structured auditing by
-default; see [docs/security](https://rosie.astro.build/docs/security/) for the full
+default; see [docs/security](https://rosieskills.dev/docs/security/) for the full
 threat model. Each defense can be disabled per call via `InstallOptions`:
 
 ```js
@@ -193,9 +193,9 @@ A standalone, self-contained `rosie` binary (built from the Rust
 implementation) is distributed separately through OS package managers, for
 users who want the CLI without a Node runtime:
 
-- Homebrew (macOS / Linux): `brew tap withastro/rosie && brew install rosie`
+- Homebrew (macOS / Linux): `brew tap rosieskills/rosie && brew install rosie`
 - Arch Linux: `yay -S rosie`
-- Debian/Ubuntu: see <https://github.com/withastro/rosie>
+- Debian/Ubuntu: see <https://github.com/rosieskills/rosie>
 - Source: clone the repo and run `cargo build --release`
 
 ## License

--- a/npm/rosie-skills/package.json
+++ b/npm/rosie-skills/package.json
@@ -22,9 +22,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/withastro/rosie.git"
+    "url": "git+https://github.com/rosieskills/rosie.git"
   },
-  "homepage": "https://github.com/withastro/rosie",
+  "homepage": "https://github.com/rosieskills/rosie",
   "license": "BSD-3-Clause",
   "author": "Matthew Phillips",
   "engines": {

--- a/tests/wrangler-integration/run.sh
+++ b/tests/wrangler-integration/run.sh
@@ -159,15 +159,15 @@ else
           const [pkgPath, pkgDir] = process.argv.slice(1);
           const p = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
           p.pnpm = p.pnpm || {};
-          // Inject our local rosie-skills build AND re-assert workers-sdk's
+          // Inject our local rosie-skills build AND re-assert the workers-sdk
           // undici-types pin. The rosie-skills file: override forces a lockfile
           // re-resolution (--no-frozen-lockfile below), during which pnpm stops
-          // honoring workers-sdk's pnpm-workspace.yaml override that pins
-          // @types/node's undici-types to 7.29.0 (matching their catalog-pinned
-          // undici). Without the re-pin, @types/node pulls undici-types@6.x into
-          // the tree and miniflare's types:build fails on the FormData type
-          // mismatch, blocking the wrangler bundle. Keep this in sync with
-          // workers-sdk's catalog:undici-types when they bump undici.
+          // honoring the pnpm-workspace.yaml override that pins the undici-types
+          // of @types/node to 7.29.0 (matching the catalog-pinned undici).
+          // Without the re-pin, @types/node pulls undici-types@6.x into the tree
+          // and the miniflare types:build fails on the FormData type mismatch,
+          // blocking the wrangler bundle. Keep in sync with the workers-sdk
+          // catalog entry for undici-types when undici is bumped.
           p.pnpm.overrides = Object.assign({}, p.pnpm.overrides, {
             "rosie-skills": "file:" + pkgDir,
             "undici-types": "7.29.0"

--- a/tests/wrangler-integration/run.sh
+++ b/tests/wrangler-integration/run.sh
@@ -159,7 +159,19 @@ else
           const [pkgPath, pkgDir] = process.argv.slice(1);
           const p = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
           p.pnpm = p.pnpm || {};
-          p.pnpm.overrides = Object.assign({}, p.pnpm.overrides, { "rosie-skills": "file:" + pkgDir });
+          // Inject our local rosie-skills build AND re-assert workers-sdk's
+          // undici-types pin. The rosie-skills file: override forces a lockfile
+          // re-resolution (--no-frozen-lockfile below), during which pnpm stops
+          // honoring workers-sdk's pnpm-workspace.yaml override that pins
+          // @types/node's undici-types to 7.29.0 (matching their catalog-pinned
+          // undici). Without the re-pin, @types/node pulls undici-types@6.x into
+          // the tree and miniflare's types:build fails on the FormData type
+          // mismatch, blocking the wrangler bundle. Keep this in sync with
+          // workers-sdk's catalog:undici-types when they bump undici.
+          p.pnpm.overrides = Object.assign({}, p.pnpm.overrides, {
+            "rosie-skills": "file:" + pkgDir,
+            "undici-types": "7.29.0"
+          });
           fs.writeFileSync(pkgPath, JSON.stringify(p, null, 2));
         ' "$ws/package.json" "$PKG"
 

--- a/tests/wrangler-integration/run.sh
+++ b/tests/wrangler-integration/run.sh
@@ -207,14 +207,19 @@ else
 
             WDIST="$ws/packages/wrangler/wrangler-dist"
             WBIN="$WDIST/cli.js"
-            META="$WDIST/metafile-cjs.json"
+            RSLINK="$ws/packages/wrangler/node_modules/rosie-skills"
             if [ ! -f "$WBIN" ]; then
                 echo "--- build log (tail) ---" >&2
                 tail -30 "$e2e/build.log" >&2
                 fail "e2e: wrangler bundle not produced ($WBIN)"
-            elif ! grep -q "rosie-skills@file" "$META" 2>/dev/null; then
+            elif ! readlink "$RSLINK" 2>/dev/null | grep -q "rosie-skills@file"; then
                 # The bundled rosie must trace back to our file: override, not a
-                # registry copy. esbuild records its inputs in the metafile.
+                # registry copy. The wrangler tsup build no longer writes a
+                # metafile (workers-sdk moved bundling to tsup+tsdown), so
+                # assert provenance at install time instead: pnpm links the
+                # overridden package from the virtual store entry named after
+                # the file: spec (rosie-skills@file+...), never from a registry
+                # version.
                 fail "e2e: bundled rosie-skills is not the local build (override did not take)"
             else
                 note "Running: wrangler setup --install-skills --dry-run --yes"

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
-# rosie.astro.build
+# rosieskills.dev
 
-The marketing site for [Rosie](https://github.com/withastro/rosie). Static assets served by a Cloudflare Worker.
+The marketing site for [Rosie](https://github.com/rosieskills/rosie). Static assets served by a Cloudflare Worker.
 
 ## Layout
 
@@ -41,14 +41,14 @@ npx wrangler dev     # http://localhost:8787
 
 ## Deploy
 
-Requires the [Cloudflare Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and a Cloudflare account where `astro.build` is configured as a zone.
+Requires the [Cloudflare Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) and a Cloudflare account where `rosieskills.dev` is configured as a zone.
 
 ```bash
 npx wrangler login   # one-time
 npm run deploy       # builds, then runs wrangler deploy
 ```
 
-The `routes` block in `wrangler.jsonc` binds the worker to `rosie.astro.build` as a custom domain. Cloudflare will provision the certificate automatically the first time.
+The `routes` block in `wrangler.jsonc` binds the worker to `rosieskills.dev` as a custom domain. Cloudflare will provision the certificate automatically the first time.
 
 ## Recording the demo (`demo.svg`)
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://rosie.astro.build',
+  site: 'https://rosieskills.dev',
   integrations: [sitemap()],
   server: {
     // 2062 — the year The Jetsons is set in. rosie was Rosey in the show.

--- a/website/public/robots.txt
+++ b/website/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://rosie.astro.build/sitemap-index.xml
+Sitemap: https://rosieskills.dev/sitemap-index.xml

--- a/website/src/content/docs/index.md
+++ b/website/src/content/docs/index.md
@@ -29,7 +29,7 @@ title: rosie
 
   <div class="cta-row">
     <a class="btn btn-primary" href="#install">[ install rosie ]</a>
-    <a class="btn btn-ghost" href="https://github.com/withastro/rosie">[ github → ]</a>
+    <a class="btn btn-ghost" href="https://github.com/rosieskills/rosie">[ github → ]</a>
   </div>
 </section>
 
@@ -101,7 +101,7 @@ title: rosie
   </div>
 
   <div class="tab-panel active" data-panel="brew">
-<pre class="term-block"><span class="prompt">$</span> brew tap withastro/rosie
+<pre class="term-block"><span class="prompt">$</span> brew tap rosieskills/rosie
 <span class="prompt">$</span> brew install rosie<button class="copy-btn" data-copy>[ copy ]</button></pre>
   </div>
 
@@ -113,7 +113,7 @@ title: rosie
 
   <div class="tab-panel" data-panel="apt">
     <p class="panel-note"><span class="comment"># noble for ubuntu 24.04 / debian 13+, jammy for ubuntu 22.04</span></p>
-<pre class="term-block"><span class="prompt">$</span> echo "deb [trusted=yes] https://pkg.rosie.astro.build/debian noble main" \
+<pre class="term-block"><span class="prompt">$</span> echo "deb [trusted=yes] https://pkg.rosieskills.dev/debian noble main" \
     | sudo tee /etc/apt/sources.list.d/rosie.list
 <span class="prompt">$</span> sudo apt update
 <span class="prompt">$</span> sudo apt install rosie<button class="copy-btn" data-copy>[ copy ]</button></pre>
@@ -124,7 +124,7 @@ title: rosie
 <pre class="term-block"><span class="prompt">$</span> sudo mkdir -p /usr/local/etc/pkg/repos
 <span class="prompt">$</span> cat &lt;&lt;'EOF' | sudo tee /usr/local/etc/pkg/repos/rosie.conf
 rosie: {
-  url: "https://pkg.rosie.astro.build/freebsd/",
+  url: "https://pkg.rosieskills.dev/freebsd/",
   enabled: yes,
   signature_type: "none"
 }
@@ -135,7 +135,7 @@ EOF
   <div class="tab-panel" data-panel="src">
     <p class="panel-note"><span class="comment"># <a href="https://rustup.rs/">install rust and cargo</a> for your platform first</span></p>
     <p class="panel-note"><span class="comment"># then clone and install (defaults to ~/.cargo/bin)</span></p>
-    <pre class="term-block"><span class="prompt">$</span> git clone https://github.com/withastro/rosie
+    <pre class="term-block"><span class="prompt">$</span> git clone https://github.com/rosieskills/rosie
 <span class="prompt">$</span> cd rosie
 <span class="prompt">$</span> cargo install --path . --locked<button class="copy-btn" data-copy>[ copy ]</button></pre>
   </div>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -12,7 +12,7 @@ const browserTitle = isMain ? 'rosie — a robot helper for agent skills' : `ros
   <meta name="description" content="A fast, cross-platform package manager for AI agent skills. Think npm, but for skills." />
   <meta property="og:title" content="rosie — a robot helper for agent skills" />
   <meta property="og:description" content="A fast, cross-platform package manager for AI agent skills." />
-  <meta property="og:url" content="https://rosie.astro.build/" />
+  <meta property="og:url" content="https://rosieskills.dev/" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <link rel="preload" href="/fonts/JetBrainsMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
@@ -26,7 +26,7 @@ const browserTitle = isMain ? 'rosie — a robot helper for agent skills' : `ros
         <span class="dot dot-yellow"></span>
         <span class="dot dot-green"></span>
       </div>
-      <div class="title">withastro/rosie — {path}</div>
+      <div class="title">rosieskills/rosie — {path}</div>
       <div class="titlebar-spacer" aria-hidden="true"></div>
     </header>
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -25,7 +25,7 @@ const { Content } = await render(entry);
   </div>
 
   <footer class="page-footer">
-    <p>rosie · BSD-3 · <a href="https://github.com/withastro/rosie">github.com/withastro/rosie</a></p>
+    <p>rosie · BSD-3 · <a href="https://github.com/rosieskills/rosie">github.com/rosieskills/rosie</a></p>
     <p class="cursor"><span class="prompt">$</span><span class="blink"></span></p>
   </footer>
 </Layout>

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -8,7 +8,7 @@
   },
   "routes": [
     {
-      "pattern": "rosie.astro.build",
+      "pattern": "rosieskills.dev",
       "custom_domain": true
     }
   ],


### PR DESCRIPTION
## Changes

- Migrates rosie off the `withastro` GitHub org and the `astro.build` Cloudflare zone: repo and Homebrew tap now live under `rosieskills`, and the site/package URLs point at `rosieskills.dev` / `pkg.rosieskills.dev`.
- Rewrites every hardcoded reference in the repo — Cargo/npm metadata, Homebrew tap clone URL + formula URL in the release workflow, AUR PKGBUILD source, Debian control, FreeBSD pkg manifest, docs site (wrangler route, astro config `site`, robots sitemap, install instructions, title/footer links), READMEs, and both release skill docs.
- Repo transfers are already done (`withastro/rosie` → `rosieskills/rosie`, `withastro/homebrew-rosie` → `rosieskills/homebrew-rosie`): history, stars, and the `gh-pages` branch preserved; old URLs redirect.

## Testing

- No product test code changed: `tests/regression/run.sh` has no org/URL references and is untouched; CI does not depend on these URLs.
- Fixes the wrangler e2e harness (`tests/wrangler-integration/run.sh`), which had broken against current workers-sdk main:
  - The e2e injects a rosie-skills `file:` override and reinstalls with `--no-frozen-lockfile`, which re-resolves the tree and drops workers-sdk's `pnpm-workspace.yaml` pin keeping `@types/node`'s `undici-types` at 7.29.0; `@types/node` then pulls `undici-types@6.x`, miniflare's `types:build` fails, and the wrangler bundle is never produced. The harness now re-pins `undici-types` to 7.29.0 alongside the rosie-skills override.
  - Wrangler's tsup build no longer emits `wrangler-dist/metafile-cjs.json`, so the old bundle-provenance assertion could never pass. The harness now asserts provenance at install time: the `file:` override must link rosie-skills from the pnpm virtual store entry `rosie-skills@file+...`, never a registry version.
  - Each failure was reproduced locally against live workers-sdk main and the fix verified before pushing (build produces `wrangler-dist/cli.js`, all turbo tasks pass).

## Docs

- Docs live in this repo and are part of this change (site URLs, install instructions). The new domains won't serve until the Cloudflare worker/R2 migration lands (remaining steps).